### PR TITLE
ebpf: reduce use of unsafe

### DIFF
--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::common::{BILLION, MILLION, PERCENTILES};
+use crate::common::{BILLION, MICROSECOND, MILLION, PERCENTILES};
 use crate::config::Config;
 use crate::samplers::Sampler;
 use crate::stats::{record_distribution, register_distribution};
@@ -15,7 +15,6 @@ use metrics::*;
 use time;
 
 use std::collections::HashMap;
-use std::mem;
 
 pub struct Block<'a> {
     config: &'a Config,
@@ -30,33 +29,21 @@ impl<'a> Block<'a> {
         let mut current = HashMap::new();
         let mut data = self.bpf.table(table);
 
-        for entry in data.iter() {
-            let mut key = entry.key;
-            let value = entry.value;
+        for mut entry in data.iter() {
+            let mut key = [0; 4];
+            key.copy_from_slice(&entry.key);
+            let key = u32::from_ne_bytes(key);
 
-            // key is a u64 index into a BPF_HISTOGRAM
-            let mut k = [0_u8; 4];
-            for (index, byte) in k.iter_mut().enumerate() {
-                *byte = *key.get(index).unwrap_or(&0);
-            }
-            let k: u32 = unsafe { mem::transmute(k) };
+            let mut value = [0; 8];
+            value.copy_from_slice(&entry.value);
+            let value = u64::from_ne_bytes(value);
 
-            // convert the key to a latency in nanoseconds
-            if let Some(latency) = super::key_to_value(k as u64) {
-                // value is a u64 count of times that block size was seen
-                let mut v = [0_u8; 8];
-                for (index, byte) in v.iter_mut().enumerate() {
-                    *byte = *value.get(index).unwrap_or(&0);
-                }
-
-                let count: u64 = unsafe { mem::transmute(v) };
-
-                // store the size-count pair into the hashmap
-                current.insert(latency * 1000, count as u32);
+            if let Some(key) = super::key_to_value(key as u64) {
+                current.insert(key * MICROSECOND, value as u32);
             }
 
             // clear the source counter
-            let _ = data.set(&mut key, &mut [0_u8; 8]);
+            let _ = data.set(&mut entry.key, &mut [0_u8; 8]);
         }
         if !self.initialized {
             self.register();
@@ -72,33 +59,21 @@ impl<'a> Block<'a> {
         let mut current = HashMap::new();
         let mut data = self.bpf.table(table);
 
-        for entry in data.iter() {
-            let mut key = entry.key;
-            let value = entry.value;
+        for mut entry in data.iter() {
+            let mut key = [0; 4];
+            key.copy_from_slice(&entry.key);
+            let key = u32::from_ne_bytes(key);
 
-            // key is a u64 index into a BPF_HISTOGRAM
-            let mut k = [0_u8; 4];
-            for (index, byte) in k.iter_mut().enumerate() {
-                *byte = *key.get(index).unwrap_or(&0);
-            }
-            let k: u32 = unsafe { mem::transmute(k) };
+            let mut value = [0; 8];
+            value.copy_from_slice(&entry.value);
+            let value = u64::from_ne_bytes(value);
 
-            // convert the key to a block size in kbytes
-            if let Some(size) = super::key_to_value(k as u64) {
-                // value is a u64 count of times that block size was seen
-                let mut v = [0_u8; 8];
-                for (index, byte) in v.iter_mut().enumerate() {
-                    *byte = *value.get(index).unwrap_or(&0);
-                }
-
-                let count: u64 = unsafe { mem::transmute(v) };
-
-                // store the size-count pair into the hashmap
-                current.insert(size, count as u32);
+            if let Some(key) = super::key_to_value(key as u64) {
+                current.insert(key, value as u32);
             }
 
             // clear the source counter
-            let _ = data.set(&mut key, &mut [0_u8; 8]);
+            let _ = data.set(&mut entry.key, &mut [0_u8; 8]);
         }
         if !self.initialized {
             self.register();

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -16,7 +16,6 @@ use metrics::*;
 use time;
 
 use std::collections::HashMap;
-use std::mem;
 
 pub struct Ext4<'a> {
     bpf: BPF,
@@ -125,33 +124,21 @@ fn map_from_table(table: &mut Table) -> HashMap<u64, u32> {
     let mut current = HashMap::new();
 
     trace!("transferring data to userspace");
-    for entry in table.iter() {
-        let mut key = entry.key;
-        let value = entry.value;
+    for mut entry in table.iter() {
+        let mut key = [0; 4];
+        key.copy_from_slice(&entry.key);
+        let key = u32::from_ne_bytes(key);
 
-        // key is a u64 index into a histogram
-        let mut k = [0_u8; 4];
-        for (index, byte) in k.iter_mut().enumerate() {
-            *byte = *key.get(index).unwrap_or(&0);
-        }
-        let k: u32 = unsafe { mem::transmute(k) };
+        let mut value = [0; 8];
+        value.copy_from_slice(&entry.value);
+        let value = u64::from_ne_bytes(value);
 
-        // convert the key to a block size in kbytes
-        if let Some(key) = super::key_to_value(k as u64) {
-            // value is a u32 count of times that block size was seen
-            let mut v = [0_u8; 8];
-            for (index, byte) in v.iter_mut().enumerate() {
-                *byte = *value.get(index).unwrap_or(&0);
-            }
-
-            let count: u64 = unsafe { mem::transmute(v) };
-
-            // store the size-count pair into the hashmap
-            current.insert(key * MICROSECOND, count as u32);
+        if let Some(key) = super::key_to_value(key as u64) {
+            current.insert(key * MICROSECOND, value as u32);
         }
 
         // clear the source counter
-        let _ = table.set(&mut key, &mut [0_u8; 8]);
+        let _ = table.set(&mut entry.key, &mut [0_u8; 8]);
     }
     current
 }

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -16,7 +16,6 @@ use metrics::*;
 use time;
 
 use std::collections::HashMap;
-use std::mem;
 
 pub struct Xfs<'a> {
     bpf: BPF,
@@ -113,33 +112,21 @@ impl<'a> Sampler<'a> for Xfs<'a> {
 
 fn map_from_table(table: &mut Table) -> HashMap<u64, u32> {
     let mut current = HashMap::new();
-    for entry in table.iter() {
-        let mut key = entry.key;
-        let value = entry.value;
+    for mut entry in table.iter() {
+        let mut key = [0; 4];
+        key.copy_from_slice(&entry.key);
+        let key = u32::from_ne_bytes(key);
 
-        // key is a u64 index into a histogram
-        let mut k = [0_u8; 4];
-        for (index, byte) in k.iter_mut().enumerate() {
-            *byte = *key.get(index).unwrap_or(&0);
-        }
-        let k: u32 = unsafe { mem::transmute(k) };
+        let mut value = [0; 8];
+        value.copy_from_slice(&entry.value);
+        let value = u64::from_ne_bytes(value);
 
-        // convert the key to a block size in kbytes
-        if let Some(key) = super::key_to_value(k as u64) {
-            // value is a u32 count of times that block size was seen
-            let mut v = [0_u8; 8];
-            for (index, byte) in v.iter_mut().enumerate() {
-                *byte = *value.get(index).unwrap_or(&0);
-            }
-
-            let count: u64 = unsafe { mem::transmute(v) };
-
-            // store the size-count pair into the hashmap
-            current.insert(key * MICROSECOND, count as u32);
+        if let Some(key) = super::key_to_value(key as u64) {
+            current.insert(key * MICROSECOND, value as u32);
         }
 
         // clear the source counter
-        let _ = table.set(&mut key, &mut [0_u8; 8]);
+        let _ = table.set(&mut entry.key, &mut [0_u8; 8]);
     }
     current
 }


### PR DESCRIPTION
Problem

As pointed out in #2 we can avoid unsafe and use the `from_ne_bytes()`
methods to do the conversion of values taken from the BPF histograms.

Solution

This changes removes the unsafe blocks and does the converstion using
safe functions.

Result

Reduces the amount of unsafe code in the codebase. Fixes #2
