### PR TITLE
ci: remove cached directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: rust
 os: linux
 dist: xenial
 sudo: required
-cache:
-  directories:
-  - $HOME/.cargo
-  - $TRAVIS_BUILD_DIR/target/debug
-  - $TRAVIS_BUILD_DIR/target/release
 matrix:
   allow_failures:
     - env: TYPE=rustfmt RUST_BACKTRACE=1


### PR DESCRIPTION
Problem

Frequently, fetching the cache content and extracting takes 
more time than would be spent building fresh and 
periodically causes timeout failures for the build job.

Solution

Removes the cache directive for TravisCI. 

Result

By removing the cache directive, we should have a more
consistent build experience in CI.
