### PR TITLE
version: bump to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "0.2.28"
+version = "1.0.0"
 dependencies = [
  "bcc 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "0.2.28"
+version = "1.0.0"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 build = "build.rs"
 publish = false


### PR DESCRIPTION
Problem

Version number was pre-release 0.2.28

Solution

Bumps the version to 1.0.0 for the initial release.

Result

Builds will reflect version 1.0.0
