### PR TITLE
build: add rust-toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ git clone https://github.com/twitter/rezolus
 cd rezolus
 
 # create an unoptimized development build
-cargo +nightly build
+cargo build
 
 # run the unoptimized binary and display help
-cargo +nightly run -- --help
+cargo run -- --help
 
 # create an optimized release build
-cargo +nightly build --release
+cargo build --release
 
 # run the optimized binary and display help
-cargo +nightly run --release -- --help
+cargo run --release -- --help
 ```
 
 ## Support

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Problem

Currently, we rely on the user specifying the nightly toolchain for this
project.

Solution

By adding a `rust-toolchain` file, we are able to instruct rustup to use the
nightly toolchain for this project.

Result

The user will not need to specify the nightly toolchain to build/run this
project. The README is updated to reflect this change.

Fixes #8 
