### PR TITLE
deps: remove x86 direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,6 @@ dependencies = [
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "x86 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ tiny_http = "0.6.2"
 toml = "0.5.1"
 uuid = "0.7.4"
 walkdir = "2.2.8"
-x86 = { version = "0.19.0", optional = true }
 
 [build-dependencies]
 vergen = "3.0.4"
@@ -39,7 +38,7 @@ ebpf_v0_7_0 = ["ebpf", "bcc/v0_7_0"]
 ebpf_v0_8_0 = ["ebpf", "bcc/v0_8_0"]
 ebpf_v0_9_0 = ["ebpf", "bcc/v0_9_0"]
 ebpf_v0_10_0 = ["ebpf", "bcc/v0_10_0"]
-perf = ["perfcnt", "x86/performance-counter"]
+perf = ["perfcnt"]
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
Problem

Unnecessary direct dependency on `x86` as pointed out in #9

Solution

Remove direct dependency on `x86`

Result

Build still works, as the dependency was not directly used. It's still a
transitive dependency for `perfcnt`, so we will remain on nightly toolchain.

Fixes #9
