### PR TITLE
logging: fix interaction between config and cli args

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -79,13 +79,15 @@ impl Config {
             Default::default()
         };
 
-        config
-            .general
-            .set_logging(match matches.occurrences_of("verbose") {
-                0 => Level::Info,
-                1 => Level::Debug,
-                _ => Level::Trace,
-            });
+        match matches.occurrences_of("verbose") {
+            0 => {} // don't do anything, default is Info
+            1 => {
+                if config.general.logging() == Level::Info {
+                    config.general.set_logging(Level::Debug);
+                }
+            }
+            _ => config.general.set_logging(Level::Trace),
+        }
 
         config
     }


### PR DESCRIPTION
Problem

The interaction between config and cli arguments for logging level result
in the logging level always being Info unless specified on the command 
line.

Solution

Changes the behavior such that the verbosity can only be increased on
the command line and not lowered.

Result

Specifying debug logging in the config will result in debug logging without
requiring command line argument to increase verbosity

Fixes #12 
