### PR TITLE
cleanup use declarations in samplers

### DIFF
--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -4,12 +4,10 @@
 
 use crate::common::*;
 use crate::config::Config;
-use crate::samplers::Sampler;
-use crate::samplers::Statistic;
-use crate::stats::record_counter;
-use crate::stats::register_counter;
-use failure::Error;
+use crate::samplers::{Sampler, Statistic};
+use crate::stats::{record_counter, register_counter};
 
+use failure::Error;
 use logger::*;
 use metrics::*;
 use serde_derive::*;

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -7,14 +7,13 @@ mod entry;
 
 pub use self::device::Device;
 pub use self::entry::Entry;
-use crate::stats::record_counter;
-use crate::stats::register_counter;
-use failure::Error;
 
 use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
+use crate::stats::{record_counter, register_counter};
 
+use failure::Error;
 use logger::*;
 use metrics::*;
 use regex::Regex;

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -6,14 +6,16 @@ use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
 use crate::stats::{record_counter, record_gauge, register_counter};
+
 use failure::Error;
 use logger::*;
 use metrics::*;
+use time;
+
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::process;
 use std::str;
-use time;
 
 pub struct Memcache<'a> {
     config: &'a Config,

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -27,8 +27,8 @@ use crate::config::Config;
 use metrics::{AtomicU32, Recorder};
 
 /// `Sampler`s are used to get samples of a particular subsystem or component
-/// The `Sampler` will send `Message`s across the `Sender` for aggregation by
-/// the stats library, `tock`
+/// The `Sampler` will perform the necessary actions to update the telemetry and
+/// record updated values into the metrics `Recorder`
 pub trait Sampler<'a> {
     fn new(
         config: &'a Config,
@@ -36,6 +36,7 @@ pub trait Sampler<'a> {
     ) -> Result<Option<Box<Self>>, Error>
     where
         Self: Sized;
+
     /// Perform required sampling steps and send stats to the `Recorder`
     fn sample(&mut self) -> Result<(), ()>;
 

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -6,13 +6,13 @@ pub(crate) mod interface;
 pub(crate) mod protocol;
 
 pub use self::interface::*;
-use crate::stats::{record_counter, register_counter};
-use failure::Error;
 
 use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
+use crate::stats::{record_counter, register_counter};
 
+use failure::Error;
 use logger::*;
 use metrics::*;
 use time;

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -5,17 +5,16 @@
 mod event;
 
 pub use self::event::PerfStatistic;
-use crate::stats::{record_counter, register_counter};
-use failure::Error;
 
 use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
+use crate::stats::{record_counter, register_counter};
 
+use failure::Error;
 use logger::*;
 use metrics::*;
-use perfcnt::AbstractPerfCounter;
-use perfcnt::PerfCounter;
+use perfcnt::{AbstractPerfCounter, PerfCounter};
 use time;
 
 use std::collections::HashMap;

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -6,14 +6,15 @@ use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
 use crate::stats::{record_counter, record_gauge, register_counter, register_gauge};
-use failure::Error;
-use std::collections::HashMap;
-use std::path::Path;
 
+use failure::Error;
 use logger::*;
 use metrics::*;
 use serde_derive::*;
 use time;
+
+use std::collections::HashMap;
+use std::path::Path;
 
 pub struct Rezolus<'a> {
     config: &'a Config,

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -6,8 +6,8 @@ use crate::common::*;
 use crate::config::Config;
 use crate::samplers::Sampler;
 use crate::stats::{record_counter, register_counter};
-use failure::Error;
 
+use failure::Error;
 use logger::*;
 use metrics::*;
 use serde_derive::*;


### PR DESCRIPTION
Problem

Use declarations in the samplers are not consistently grouped

Solution

Group the use declarations and make organization more consistent

Result

Use declarations are consistently grouped within samplers
