### PR TITLE
sampler: make memcache sampler more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
+# [Unreleased]
+## Fixed
+- Allows memcache sampler to reconnect to the cache instance which helps to make
+  the sampler more resilient to transient errors
+
 # [1.0.1] - 2019-08-22
-### Fixed
+## Fixed
 - Fixes interaction between command line arguments and config file so that
   logging level can be set in the config
 
 # [1.0.0] - 2019-08-20
 
 Initial release.
+
+[Unreleased]: https://github.com/twitter/rezolus/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/twitter/rezolus/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/twitter/rezolus/releases/tag/v1.0.0


### PR DESCRIPTION
Problem

Current memcache sampler expects the cache instance to be fully
initialized before running and is not tolerant of faults.

Solution

Makes the sampler more resilient by allowing reconnect attempts to the
cache instance.

Result

Memcache sampler should be more tolerant of transient errors occuring
both at startup and at runtime.
