### PR TITLE
config: use atomics for sampler enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Fixed
 - Allows memcache sampler to reconnect to the cache instance which helps to make
   the sampler more resilient to transient errors
+- Softnet sampler now disabled by default to be consistent with other samplers
 
 # [1.0.1] - 2019-08-22
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
 name = "rezolus"
 version = "1.0.2-alpha.0"
 dependencies = [
+ "atomics 0.2.0 (git+https://github.com/twitter/rpc-perf)",
  "bcc 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = '2018'
 
 [dependencies]
+atomics = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 bcc = { version = "0.0.10", optional = true }
 clap = "2.33.0"
 failure = "0.1.5"

--- a/src/config/cpu.rs
+++ b/src/config/cpu.rs
@@ -4,7 +4,8 @@
 
 use crate::config::*;
 use crate::samplers::cpu::CpuStatistic;
-use core::sync::atomic::{AtomicBool, Ordering};
+
+use atomics::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/config/disk.rs
+++ b/src/config/disk.rs
@@ -3,7 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::config::*;
-use core::sync::atomic::{AtomicBool, Ordering};
+
+use atomics::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/config/ebpf.rs
+++ b/src/config/ebpf.rs
@@ -3,7 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::config::*;
-use core::sync::atomic::{AtomicBool, Ordering};
+
+use atomics::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -3,7 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::config::*;
-use core::sync::atomic::{AtomicUsize, Ordering};
+
+use atomics::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -3,15 +3,16 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::config::*;
-
 use crate::samplers::network::interface::InterfaceStatistic;
 use crate::samplers::network::protocol::ProtocolStatistic;
 
-#[derive(Clone, Debug, Deserialize)]
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Network {
     #[serde(default = "default_enabled")]
-    enabled: bool,
+    enabled: AtomicBool,
     #[serde(default = "default_interface_statistics")]
     interface_statistics: Vec<InterfaceStatistic>,
     #[serde(default = "default_protocol_statistics")]
@@ -28,8 +29,8 @@ impl Default for Network {
     }
 }
 
-fn default_enabled() -> bool {
-    false
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
 }
 
 fn default_interface_statistics() -> Vec<InterfaceStatistic> {
@@ -65,7 +66,7 @@ fn default_protocol_statistics() -> Vec<ProtocolStatistic> {
 
 impl Network {
     pub fn enabled(&self) -> bool {
-        self.enabled
+        self.enabled.load(Ordering::Relaxed)
     }
 
     pub fn interface_statistics(&self) -> &[InterfaceStatistic] {

--- a/src/config/perf.rs
+++ b/src/config/perf.rs
@@ -5,11 +5,13 @@
 use crate::config::*;
 use crate::samplers::perf::PerfStatistic;
 
-#[derive(Clone, Debug, Deserialize)]
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Perf {
     #[serde(default = "default_enabled")]
-    enabled: bool,
+    enabled: AtomicBool,
     #[serde(default = "default_statistics")]
     statistics: Vec<PerfStatistic>,
 }
@@ -23,8 +25,8 @@ impl Default for Perf {
     }
 }
 
-fn default_enabled() -> bool {
-    false
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
 }
 
 fn default_statistics() -> Vec<PerfStatistic> {
@@ -54,7 +56,7 @@ fn default_statistics() -> Vec<PerfStatistic> {
 
 impl Perf {
     pub fn enabled(&self) -> bool {
-        self.enabled
+        self.enabled.load(Ordering::Relaxed)
     }
 
     pub fn statistics(&self) -> &[PerfStatistic] {

--- a/src/config/softnet.rs
+++ b/src/config/softnet.rs
@@ -4,11 +4,13 @@
 
 use crate::config::*;
 
-#[derive(Clone, Debug, Deserialize)]
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Softnet {
     #[serde(default = "default_enabled")]
-    enabled: bool,
+    enabled: AtomicBool,
 }
 
 impl Default for Softnet {
@@ -19,12 +21,12 @@ impl Default for Softnet {
     }
 }
 
-fn default_enabled() -> bool {
-    true
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
 }
 
 impl Softnet {
     pub fn enabled(&self) -> bool {
-        self.enabled
+        self.enabled.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
Problem

Sampler enabled status was not atomic for all samplers. Softnet defaulted to
enabled

Solution

Use `AtomicBool` for all sampler enabled status. Change softnet to diabled by
default

