### PR TITLE
samplers: add container sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # [Unreleased]
+## Added
+- Container sampler to use within an application container for telemetry
+
 ## Fixed
 - Allows memcache sampler to reconnect to the cache instance which helps to make
   the sampler more resilient to transient errors

--- a/configs/container.toml
+++ b/configs/container.toml
@@ -1,0 +1,29 @@
+# This config is an example for running Rezolus within an application container.
+# It is intended to be run within the container as a "sidecar" process and used
+# to export additional telemetry about the container.
+
+# settings that apply to the entire process
+[general]
+
+# socket address for the metrics endpoint
+listen = "0.0.0.0:4242"
+
+# integration period for histograms in seconds
+window = 60
+
+# default collection interval for each sampler in milliseconds
+interval = 1000
+
+# per-sampler timeout in milliseconds
+timeout = 50
+
+# per-sampler max for consecutive timeouts before disabling that sampler
+max_timeouts = 5
+
+
+
+# settings for basic container telemetry
+[conmtainer]
+
+# enable or disable collection
+enabled = true

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -1,3 +1,7 @@
+# This config is an example for running Rezolus for system-level telemetry. It
+# is intended to be run as an agent on the machine to export systems performance
+# telemetry.
+
 # settings that apply to the entire process
 [general]
 

--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -1,0 +1,32 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::config::*;
+
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Container {
+    #[serde(default = "default_enabled")]
+    enabled: AtomicBool,
+}
+
+impl Default for Container {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+        }
+    }
+}
+
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
+}
+
+impl Container {
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+mod container;
 mod cpu;
 mod disk;
 mod ebpf;
@@ -10,6 +11,7 @@ mod network;
 mod perf;
 mod softnet;
 
+use self::container::Container;
 use self::cpu::Cpu;
 use self::disk::Disk;
 use self::ebpf::Ebpf;
@@ -32,6 +34,8 @@ pub const NAME: &str = env!("CARGO_PKG_NAME");
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(default)]
+    container: Container,
     #[serde(default)]
     cpu: Cpu,
     #[serde(default)]
@@ -112,6 +116,10 @@ impl Config {
 
     pub fn stats_log(&self) -> Option<String> {
         self.general.stats_log()
+    }
+
+    pub fn container(&self) -> &Container {
+        &self.container
     }
 
     pub fn cpu(&self) -> &Cpu {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,9 @@ fn main() {
             samplers.push((s, Stats::default()));
         }
     } else {
+        if let Ok(Some(s)) = samplers::Container::new(&config, &recorder) {
+            samplers.push((s, Stats::default()));
+        }
         if let Ok(Some(s)) = samplers::Cpu::new(&config, &recorder) {
             samplers.push((s, Stats::default()));
         }

--- a/src/samplers/container/mod.rs
+++ b/src/samplers/container/mod.rs
@@ -1,0 +1,153 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::common::*;
+use crate::config::Config;
+use crate::samplers::Sampler;
+use crate::stats::{record_counter, register_counter};
+
+use failure::*;
+use logger::*;
+use metrics::*;
+use time;
+
+use std::io::{BufRead, BufReader};
+
+pub struct Container<'a> {
+    config: &'a Config,
+    cgroup: Option<String>,
+    initialized: bool,
+    nanos_per_tick: u64,
+    recorder: &'a Recorder<AtomicU32>,
+}
+
+impl<'a> Sampler<'a> for Container<'a> {
+    fn new(
+        config: &'a Config,
+        recorder: &'a Recorder<AtomicU32>,
+    ) -> Result<Option<Box<Self>>, Error> {
+        if config.container().enabled() {
+            let mut cgroup = None;
+            let path = format!("/proc/{}/cgroup", std::process::id());
+            let file = std::fs::File::open(&path).map_err(|e| {
+                format_err!(
+                    "failed to open file ({:?}): {}",
+                    path,
+                    e
+                )
+            })?;
+            let f = BufReader::new(file);
+            for line in f.lines() {
+                let line = line.unwrap();
+                let parts: Vec<&str> = line.split(':').collect();
+                if parts.len() == 3 {
+                    if parts[1] == "cpu,cpuacct" {
+                        cgroup = Some(parts[2].to_string());
+                    }
+                }
+            }
+            if cgroup.is_some() {
+                Ok(Some(Box::new(Container {
+                    config,
+                    cgroup,
+                    initialized: false,
+                    nanos_per_tick: crate::common::nanos_per_tick(),
+                    recorder,
+                })))
+            } else {
+                Err(format_err!("failed to find cgroup"))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn name(&self) -> String {
+        "container".to_string()
+    }
+
+    fn sample(&mut self) -> Result<(), ()> {
+        // gather current state
+        trace!("sampling {}", self.name());
+        self.register();
+        let time = time::precise_time_ns();
+        
+        let mut total = 0;
+
+        let path = format!("/sys/fs/cgroup/cpu,cpuacct{}/cpuacct.stat", self.cgroup.as_ref().unwrap());
+        if let Ok(file) = std::fs::File::open(&path) {
+        	let file = BufReader::new(file);
+        	for line in file.lines() {
+        		if let Ok(line) = line {
+        			let parts: Vec<&str> = line.split(' ').collect();
+        			if parts.len() == 2 {
+        				match parts[0] {
+        					"system" => {
+        						if let Ok(ticks) = parts[1].parse::<u64>() {
+        							let ns = ticks * self.nanos_per_tick;
+        							record_counter(self.recorder, "container/cpu/system", time, ns);
+                                    total += ns;
+        						}
+        					}
+        					"user" => {
+        						if let Ok(ticks) = parts[1].parse::<u64>() {
+        							let ns = ticks * self.nanos_per_tick;
+        							record_counter(self.recorder, "container/cpu/user", time, ns);
+                                    total += ns;
+        						}
+        					}
+        					&_ => {}
+        				}
+        			}
+        		}
+        	}
+        }
+
+        if total != 0 {
+            record_counter(self.recorder, "container/cpu/total", time, total);
+        }
+
+        Ok(())
+    }
+
+    fn register(&mut self) {
+        if !self.initialized {
+        	let cores = crate::common::hardware_threads().unwrap_or(1);
+        	register_counter(
+                self.recorder,
+                "container/cpu/total",
+                2 * cores * SECOND,
+                3,
+                self.config.general().window(),
+                PERCENTILES,
+            );
+            register_counter(
+                self.recorder,
+                "container/cpu/system",
+                2 * cores * SECOND,
+                3,
+                self.config.general().window(),
+                PERCENTILES,
+            );
+            register_counter(
+                self.recorder,
+                "container/cpu/user",
+                2 * cores * SECOND,
+                3,
+                self.config.general().window(),
+                PERCENTILES,
+            );
+        	self.initialized = true;
+        }
+    }
+
+    fn deregister(&mut self) {
+        if self.initialized {
+        	self.recorder.delete_channel("container/cpu/total".to_string());
+        	self.recorder.delete_channel("container/cpu/system".to_string());
+        	self.recorder.delete_channel("container/cpu/user".to_string());
+        	self.initialized = false;
+        }
+    }
+}

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+pub(crate) mod container;
 pub(crate) mod cpu;
 pub(crate) mod disk;
 #[cfg(feature = "ebpf")]
@@ -13,6 +14,7 @@ pub(crate) mod perf;
 pub(crate) mod rezolus;
 pub(crate) mod softnet;
 
+pub use self::container::Container;
 pub use self::cpu::Cpu;
 pub use self::disk::Disk;
 pub use self::memcache::Memcache;


### PR DESCRIPTION
Problem

We don't have a sampler to enabled Rezolus to be deployed within a
container and report telemetry for the container it is in.

Solution

Adds a container sampler which tracks cpu utilization for the cgroup
which Rezolus is running in.

Result

Adds basic container telemetry
