### PR TITLE
fix typo in example config

### DIFF
--- a/configs/container.toml
+++ b/configs/container.toml
@@ -23,7 +23,7 @@ max_timeouts = 5
 
 
 # settings for basic container telemetry
-[conmtainer]
+[container]
 
 # enable or disable collection
 enabled = true


### PR DESCRIPTION
Problem

Typo in example config for container telemetry

Solution

Fix the typo
