### PR TITLE
refactor samplers to use common struct

### DIFF
--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -148,20 +148,14 @@ impl<'a> Rezolus<'a> {
         let user_seconds = (*parsed.get(&ProcessStat::UserTime).unwrap_or(&0)
             + *parsed.get(&ProcessStat::ChildrenUserTime).unwrap_or(&0))
             * nanos_per_tick();
-        self.common.record_counter(
-            &Statistic::CpuUser,
-            time,
-            user_seconds,
-        );
+        self.common
+            .record_counter(&Statistic::CpuUser, time, user_seconds);
 
         let kernel_seconds = (*parsed.get(&ProcessStat::SystemTime).unwrap_or(&0)
             + *parsed.get(&ProcessStat::ChildrenSystemTime).unwrap_or(&0))
             * nanos_per_tick();
-        self.common.record_counter(
-            &Statistic::CpuKernel,
-            time,
-            kernel_seconds,
-        );
+        self.common
+            .record_counter(&Statistic::CpuKernel, time, kernel_seconds);
     }
 }
 
@@ -192,10 +186,12 @@ impl<'a> Sampler<'a> for Rezolus<'a> {
         if !self.initialized {
             trace!("register {}", self.name());
             for label in self.gauges() {
-                self.common.register_gauge(&label, 32 * TERABYTE, 3, &[Percentile::Maximum]);
+                self.common
+                    .register_gauge(&label, 32 * TERABYTE, 3, &[Percentile::Maximum]);
             }
             for label in self.counters() {
-                self.common.register_counter(&label, BILLION, 3, &[Percentile::Maximum]);
+                self.common
+                    .register_counter(&label, BILLION, 3, &[Percentile::Maximum]);
             }
             self.initialized = true;
         }
@@ -205,10 +201,10 @@ impl<'a> Sampler<'a> for Rezolus<'a> {
         if self.initialized {
             trace!("deregister {}", self.name());
             for label in self.gauges() {
-                self.common.delete_channel(label.clone());
+                self.common.delete_channel(&label);
             }
             for label in self.counters() {
-                self.common.delete_channel(label.clone());
+                self.common.delete_channel(&label);
             }
             self.initialized = false;
         }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -7,7 +7,6 @@
 mod http;
 
 pub use self::http::Http;
-use std::time::Duration;
 
 use metrics::*;
 
@@ -99,98 +98,5 @@ impl StatsLog {
             std::thread::sleep(std::time::Duration::new(60, 0));
             self.print();
         }
-    }
-}
-
-pub fn record_counter<T>(recorder: &Recorder<AtomicU32>, label: T, time: u64, value: u64)
-where
-    T: ToString,
-{
-    recorder.record(label.to_string(), Measurement::Counter { time, value });
-}
-
-pub fn record_gauge<T>(recorder: &Recorder<AtomicU32>, label: T, time: u64, value: u64)
-where
-    T: ToString,
-{
-    recorder.record(label.to_string(), Measurement::Gauge { time, value });
-}
-
-pub fn record_distribution<T>(
-    recorder: &Recorder<AtomicU32>,
-    label: T,
-    time: u64,
-    value: u64,
-    count: u32,
-) where
-    T: ToString,
-{
-    recorder.record(
-        label.to_string(),
-        Measurement::Distribution { time, value, count },
-    );
-}
-
-pub fn register_counter<T>(
-    recorder: &Recorder<AtomicU32>,
-    label: T,
-    max: u64,
-    precision: u32,
-    duration: Duration,
-    percentiles: &[Percentile],
-) where
-    T: ToString,
-{
-    recorder.add_channel(
-        label.to_string(),
-        Source::Counter,
-        Some(Histogram::new(max, precision, Some(duration), None)),
-    );
-    recorder.add_output(label.to_string(), Output::Counter);
-    recorder.add_output(label.to_string(), Output::MaxPointTime);
-    for percentile in percentiles {
-        recorder.add_output(label.to_string(), Output::Percentile(*percentile));
-    }
-}
-
-pub fn register_gauge<T>(
-    recorder: &Recorder<AtomicU32>,
-    label: T,
-    max: u64,
-    precision: u32,
-    duration: Duration,
-    percentiles: &[Percentile],
-) where
-    T: ToString,
-{
-    recorder.add_channel(
-        label.to_string(),
-        Source::Gauge,
-        Some(Histogram::new(max, precision, Some(duration), None)),
-    );
-    recorder.add_output(label.to_string(), Output::Counter);
-    recorder.add_output(label.to_string(), Output::MaxPointTime);
-    for percentile in percentiles {
-        recorder.add_output(label.to_string(), Output::Percentile(*percentile));
-    }
-}
-
-pub fn register_distribution<T>(
-    recorder: &Recorder<AtomicU32>,
-    label: T,
-    max: u64,
-    precision: u32,
-    duration: Duration,
-    percentiles: &[Percentile],
-) where
-    T: ToString,
-{
-    recorder.add_channel(
-        label.to_string(),
-        Source::Distribution,
-        Some(Histogram::new(max, precision, Some(duration), None)),
-    );
-    for &percentile in percentiles {
-        recorder.add_output(label.to_string(), Output::Percentile(percentile));
     }
 }


### PR DESCRIPTION
Problem

Remaining samplers should be refactored to use the `samplers::Common` struct

Solution

Refactored remaining samplers

Result

`samplers::Common` now used by all samplers. Allowing for future refactoring.