### PR TITLE
refactoring softnet

### DIFF
--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+mod statistics;
+
 use crate::common::*;
 use crate::config::Config;
 use crate::samplers::{Common, Sampler};
+use self::statistics::Statistic;
 
 use failure::Error;
 use logger::*;
 use metrics::*;
-use serde_derive::*;
 use time;
 
 use std::collections::HashMap;
@@ -18,43 +20,6 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 const SOFTNET_STAT: &str = "/proc/net/softnet_stat";
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields, rename_all = "lowercase")]
-pub enum Statistic {
-    Processed,
-    Dropped,
-    TimeSqueezed,
-    CpuCollision,
-    ReceivedRps,
-    FlowLimitCount,
-}
-
-impl std::fmt::Display for Statistic {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Statistic::Processed => write!(f, "softnet/processed"),
-            Statistic::Dropped => write!(f, "softnet/dropped"),
-            Statistic::TimeSqueezed => write!(f, "softnet/time_squeezed"),
-            Statistic::CpuCollision => write!(f, "softnet/cpu_collision"),
-            Statistic::ReceivedRps => write!(f, "softnet/received_rps"),
-            Statistic::FlowLimitCount => write!(f, "softnet/flow_limit_count"),
-        }
-    }
-}
-
-impl Statistic {
-    fn field_number(&self) -> usize {
-        match self {
-            Statistic::Processed => 0,
-            Statistic::Dropped => 1,
-            Statistic::TimeSqueezed => 2,
-            Statistic::CpuCollision => 3,
-            Statistic::ReceivedRps => 4,
-            Statistic::FlowLimitCount => 5,
-        }
-    }
-}
 
 pub struct Softnet<'a> {
     common: Common<'a>,

--- a/src/samplers/softnet/statistics.rs
+++ b/src/samplers/softnet/statistics.rs
@@ -1,0 +1,42 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use serde_derive::*;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub enum Statistic {
+    Processed,
+    Dropped,
+    TimeSqueezed,
+    CpuCollision,
+    ReceivedRps,
+    FlowLimitCount,
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Statistic::Processed => write!(f, "softnet/processed"),
+            Statistic::Dropped => write!(f, "softnet/dropped"),
+            Statistic::TimeSqueezed => write!(f, "softnet/time_squeezed"),
+            Statistic::CpuCollision => write!(f, "softnet/cpu_collision"),
+            Statistic::ReceivedRps => write!(f, "softnet/received_rps"),
+            Statistic::FlowLimitCount => write!(f, "softnet/flow_limit_count"),
+        }
+    }
+}
+
+impl Statistic {
+    pub fn field_number(&self) -> usize {
+        match self {
+            Statistic::Processed => 0,
+            Statistic::Dropped => 1,
+            Statistic::TimeSqueezed => 2,
+            Statistic::CpuCollision => 3,
+            Statistic::ReceivedRps => 4,
+            Statistic::FlowLimitCount => 5,
+        }
+    }
+}


### PR DESCRIPTION
Refactors softnet sampler to move the `Statistic` enum out into its
own module.