### PR TITLE
refactor network sampler

### DIFF
--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -3,8 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::config::*;
-use crate::samplers::network::interface::InterfaceStatistic;
-use crate::samplers::network::protocol::ProtocolStatistic;
+use crate::samplers::network::statistics::*;
 
 use atomics::*;
 

--- a/src/samplers/network/interface.rs
+++ b/src/samplers/network/interface.rs
@@ -3,9 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::common::net;
-use crate::samplers::Statistic;
-
-use serde_derive::*;
+use crate::samplers::network::statistics::InterfaceStatistic;
 
 use std::fmt;
 
@@ -45,116 +43,6 @@ impl Interface {
             net::read_network_stat(&name, statistic.name())
         } else {
             Err(())
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum InterfaceStatistic {
-    /// Indicates the number of bytes received by this network device.
-    /// See the network driver for the exact meaning of when this
-    /// value is incremented.
-    RxBytes,
-    /// Indicates the number of packets received with a CRC (FCS) error
-    /// by this network device. Note that the specific meaning might
-    /// depend on the MAC layer used by the interface.
-    RxCrcErrors,
-    /// The number of received packets dropped due to lack of buffers on a
-    /// physical port. If this counter is increasing, it implies that the
-    /// adapter is congested and cannot absorb the traffic coming from the
-    /// network.
-    RxDiscardsPhy,
-    /// Indicates the number of packets received by the network device
-    /// but dropped, that are not forwarded to the upper layers for
-    /// packet processing. See the network driver for the exact
-    /// meaning of this value.
-    RxDropped,
-    RxErrors,
-    /// Indicates the number of receive FIFO errors seen by this
-    /// network device. See the network driver for the exact
-    /// meaning of this value.
-    /// drivers: mlx4
-    RxFifoErrors,
-    /// Indicates the number of received packets that have been missed
-    /// due to lack of capacity in the receive side. See the network
-    /// driver for the exact meaning of this value.
-    /// drivers: ixgbe
-    RxMissedErrors,
-    /// Indicates the total number of good packets received by this
-    /// network device.
-    RxPackets,
-    /// Indicates the number of bytes transmitted by a network
-    /// device. See the network driver for the exact meaning of this
-    /// value, in particular whether this accounts for all successfully
-    /// transmitted packets or all packets that have been queued for
-    /// transmission.
-    TxBytes,
-    /// The number of transmit packets dropped due to lack of buffers on a
-    /// physical port. If this counter is increasing, it implies that the
-    /// adapter is congested and cannot absorb the traffic coming from the
-    /// network.
-    /// drivers: mlx5
-    TxDiscardsPhy,
-    /// Indicates the number of packets dropped during transmission.
-    /// See the driver for the exact reasons as to why the packets were
-    /// dropped.
-    TxDropped,
-    /// Indicates the number of packets in error during transmission by
-    /// a network device. See the driver for the exact reasons as to
-    /// why the packets were dropped.
-    TxErrors,
-    /// Indicates the number of packets having caused a transmit
-    /// FIFO error. See the driver for the exact reasons as to why the
-    /// packets were dropped.
-    /// drivers: mlx4
-    TxFifoErrors,
-    /// Indicates the number of packets transmitted by a network
-    /// device. See the driver for whether this reports the number of all
-    /// attempted or successful transmissions.
-    TxPackets,
-}
-
-impl fmt::Display for InterfaceStatistic {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            InterfaceStatistic::RxBytes => write!(f, "network/receive/bytes"),
-            InterfaceStatistic::RxCrcErrors => write!(f, "network/receive/errors/crc"),
-            InterfaceStatistic::RxDiscardsPhy => write!(f, "network/receive/errors/discards_phy"),
-            InterfaceStatistic::RxDropped => write!(f, "network/receive/dropped"),
-            InterfaceStatistic::RxErrors => write!(f, "network/receive/errors/total"),
-            InterfaceStatistic::RxFifoErrors => write!(f, "network/receive/errors/fifo"),
-            InterfaceStatistic::RxMissedErrors => write!(f, "network/receive/errors/missed"),
-            InterfaceStatistic::RxPackets => write!(f, "network/receive/packets"),
-            InterfaceStatistic::TxBytes => write!(f, "network/transmit/bytes"),
-            InterfaceStatistic::TxDiscardsPhy => write!(f, "network/transmit/errors/discards_phy"),
-            InterfaceStatistic::TxDropped => write!(f, "network/transmit/dropped"),
-            InterfaceStatistic::TxErrors => write!(f, "network/transmit/errors/total"),
-            InterfaceStatistic::TxFifoErrors => write!(f, "network/transmit/errors/fifo"),
-            InterfaceStatistic::TxPackets => write!(f, "network/transmit/packets"),
-        }
-    }
-}
-
-impl Statistic for InterfaceStatistic {}
-
-impl InterfaceStatistic {
-    pub fn name(&self) -> &str {
-        match self {
-            InterfaceStatistic::RxBytes => "rx_bytes",
-            InterfaceStatistic::RxCrcErrors => "rx_crc_errors",
-            InterfaceStatistic::RxDropped => "rx_dropped",
-            InterfaceStatistic::RxDiscardsPhy => "rx_discards_phy",
-            InterfaceStatistic::RxErrors => "rx_errors",
-            InterfaceStatistic::RxFifoErrors => "rx_fifo_errors",
-            InterfaceStatistic::RxMissedErrors => "rx_missed_errors",
-            InterfaceStatistic::RxPackets => "rx_packets",
-            InterfaceStatistic::TxBytes => "tx_bytes",
-            InterfaceStatistic::TxDiscardsPhy => "tx_discards_phy",
-            InterfaceStatistic::TxDropped => "tx_dropped",
-            InterfaceStatistic::TxErrors => "tx_errors",
-            InterfaceStatistic::TxFifoErrors => "tx_fifo_errors",
-            InterfaceStatistic::TxPackets => "tx_packets",
         }
     }
 }

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -4,12 +4,14 @@
 
 pub(crate) mod interface;
 pub(crate) mod protocol;
+pub(crate) mod statistics;
 
 pub use self::interface::*;
 
 use crate::common::*;
 use crate::config::Config;
 use crate::samplers::{Common, Sampler};
+use self::statistics::InterfaceStatistic;
 
 use failure::Error;
 use logger::*;
@@ -94,7 +96,7 @@ impl<'a> Sampler<'a> for Network<'a> {
                 .iter()
                 .map(|i| i.get_statistic(&statistic).unwrap_or(0))
                 .sum();
-            self.common.record_counter(statistic, time, sum);
+            self.common.record_counter(&statistic, time, sum);
         }
 
         // protocol statistics
@@ -126,7 +128,7 @@ impl<'a> Sampler<'a> for Network<'a> {
                     }
                     _ => (2 * total_bandwidth_bytes / 64),
                 };
-                self.common.register_counter(statistic, max, 3, PERCENTILES);
+                self.common.register_counter(&statistic, max, 3, PERCENTILES);
             }
             for statistic in self.common.config().network().protocol_statistics() {
                 let max = 2 * total_bandwidth_bytes / 64;

--- a/src/samplers/network/protocol.rs
+++ b/src/samplers/network/protocol.rs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::samplers::Statistic;
-use std::collections::HashMap;
-use std::fmt;
+use crate::network::statistics::ProtocolStatistic;
 
-use serde_derive::*;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct Protocol {
@@ -26,63 +24,6 @@ impl Protocol {
             inner.get(statistic.name())
         } else {
             None
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum ProtocolStatistic {
-    TcpInSegs,
-    TcpOutSegs,
-    TcpPruneCalled,
-    TcpRcvCollapsed,
-    TcpRetransSegs,
-    UdpInDatagrams,
-    UdpInErrors,
-    UdpOutDatagrams,
-}
-
-impl fmt::Display for ProtocolStatistic {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ProtocolStatistic::TcpInSegs => write!(f, "network/tcp/receive/segments"),
-            ProtocolStatistic::TcpOutSegs => write!(f, "network/tcp/transmit/segments"),
-            ProtocolStatistic::TcpPruneCalled => write!(f, "network/tcp/receive/prune_called"),
-            ProtocolStatistic::TcpRcvCollapsed => write!(f, "network/tcp/receive/collapsed"),
-            ProtocolStatistic::TcpRetransSegs => write!(f, "network/tcp/transmit/retranmits"),
-            ProtocolStatistic::UdpInDatagrams => write!(f, "network/udp/receive/datagrams"),
-            ProtocolStatistic::UdpInErrors => write!(f, "network/udp/receive/errors"),
-            ProtocolStatistic::UdpOutDatagrams => write!(f, "network/udp/transmit/datagrams"),
-        }
-    }
-}
-
-impl Statistic for ProtocolStatistic {}
-
-impl ProtocolStatistic {
-    pub fn name(&self) -> &str {
-        match self {
-            ProtocolStatistic::TcpInSegs => "InSegs",
-            ProtocolStatistic::TcpOutSegs => "OutSegs",
-            ProtocolStatistic::TcpPruneCalled => "PruneCalled",
-            ProtocolStatistic::TcpRcvCollapsed => "TCPRcvCollapsed",
-            ProtocolStatistic::TcpRetransSegs => "RetransSegs",
-            ProtocolStatistic::UdpInDatagrams => "InDatagrams",
-            ProtocolStatistic::UdpInErrors => "InErrors",
-            ProtocolStatistic::UdpOutDatagrams => "OutDatagrams",
-        }
-    }
-
-    pub fn protocol(&self) -> &str {
-        match self {
-            ProtocolStatistic::TcpInSegs
-            | ProtocolStatistic::TcpOutSegs
-            | ProtocolStatistic::TcpRetransSegs => "Tcp:",
-            ProtocolStatistic::TcpPruneCalled | ProtocolStatistic::TcpRcvCollapsed => "TcpExt:",
-            ProtocolStatistic::UdpInDatagrams
-            | ProtocolStatistic::UdpInErrors
-            | ProtocolStatistic::UdpOutDatagrams => "Udp:",
         }
     }
 }

--- a/src/samplers/network/statistics.rs
+++ b/src/samplers/network/statistics.rs
@@ -1,0 +1,169 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use serde_derive::*;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum InterfaceStatistic {
+    /// Indicates the number of bytes received by this network device.
+    /// See the network driver for the exact meaning of when this
+    /// value is incremented.
+    RxBytes,
+    /// Indicates the number of packets received with a CRC (FCS) error
+    /// by this network device. Note that the specific meaning might
+    /// depend on the MAC layer used by the interface.
+    RxCrcErrors,
+    /// The number of received packets dropped due to lack of buffers on a
+    /// physical port. If this counter is increasing, it implies that the
+    /// adapter is congested and cannot absorb the traffic coming from the
+    /// network.
+    RxDiscardsPhy,
+    /// Indicates the number of packets received by the network device
+    /// but dropped, that are not forwarded to the upper layers for
+    /// packet processing. See the network driver for the exact
+    /// meaning of this value.
+    RxDropped,
+    RxErrors,
+    /// Indicates the number of receive FIFO errors seen by this
+    /// network device. See the network driver for the exact
+    /// meaning of this value.
+    /// drivers: mlx4
+    RxFifoErrors,
+    /// Indicates the number of received packets that have been missed
+    /// due to lack of capacity in the receive side. See the network
+    /// driver for the exact meaning of this value.
+    /// drivers: ixgbe
+    RxMissedErrors,
+    /// Indicates the total number of good packets received by this
+    /// network device.
+    RxPackets,
+    /// Indicates the number of bytes transmitted by a network
+    /// device. See the network driver for the exact meaning of this
+    /// value, in particular whether this accounts for all successfully
+    /// transmitted packets or all packets that have been queued for
+    /// transmission.
+    TxBytes,
+    /// The number of transmit packets dropped due to lack of buffers on a
+    /// physical port. If this counter is increasing, it implies that the
+    /// adapter is congested and cannot absorb the traffic coming from the
+    /// network.
+    /// drivers: mlx5
+    TxDiscardsPhy,
+    /// Indicates the number of packets dropped during transmission.
+    /// See the driver for the exact reasons as to why the packets were
+    /// dropped.
+    TxDropped,
+    /// Indicates the number of packets in error during transmission by
+    /// a network device. See the driver for the exact reasons as to
+    /// why the packets were dropped.
+    TxErrors,
+    /// Indicates the number of packets having caused a transmit
+    /// FIFO error. See the driver for the exact reasons as to why the
+    /// packets were dropped.
+    /// drivers: mlx4
+    TxFifoErrors,
+    /// Indicates the number of packets transmitted by a network
+    /// device. See the driver for whether this reports the number of all
+    /// attempted or successful transmissions.
+    TxPackets,
+}
+
+impl std::fmt::Display for InterfaceStatistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::RxBytes => write!(f, "network/receive/bytes"),
+            Self::RxCrcErrors => write!(f, "network/receive/errors/crc"),
+            Self::RxDiscardsPhy => write!(f, "network/receive/errors/discards_phy"),
+            Self::RxDropped => write!(f, "network/receive/dropped"),
+            Self::RxErrors => write!(f, "network/receive/errors/total"),
+            Self::RxFifoErrors => write!(f, "network/receive/errors/fifo"),
+            Self::RxMissedErrors => write!(f, "network/receive/errors/missed"),
+            Self::RxPackets => write!(f, "network/receive/packets"),
+            Self::TxBytes => write!(f, "network/transmit/bytes"),
+            Self::TxDiscardsPhy => write!(f, "network/transmit/errors/discards_phy"),
+            Self::TxDropped => write!(f, "network/transmit/dropped"),
+            Self::TxErrors => write!(f, "network/transmit/errors/total"),
+            Self::TxFifoErrors => write!(f, "network/transmit/errors/fifo"),
+            Self::TxPackets => write!(f, "network/transmit/packets"),
+        }
+    }
+}
+
+impl InterfaceStatistic {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::RxBytes => "rx_bytes",
+            Self::RxCrcErrors => "rx_crc_errors",
+            Self::RxDropped => "rx_dropped",
+            Self::RxDiscardsPhy => "rx_discards_phy",
+            Self::RxErrors => "rx_errors",
+            Self::RxFifoErrors => "rx_fifo_errors",
+            Self::RxMissedErrors => "rx_missed_errors",
+            Self::RxPackets => "rx_packets",
+            Self::TxBytes => "tx_bytes",
+            Self::TxDiscardsPhy => "tx_discards_phy",
+            Self::TxDropped => "tx_dropped",
+            Self::TxErrors => "tx_errors",
+            Self::TxFifoErrors => "tx_fifo_errors",
+            Self::TxPackets => "tx_packets",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Hash)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum ProtocolStatistic {
+    TcpInSegs,
+    TcpOutSegs,
+    TcpPruneCalled,
+    TcpRcvCollapsed,
+    TcpRetransSegs,
+    UdpInDatagrams,
+    UdpInErrors,
+    UdpOutDatagrams,
+}
+
+impl std::fmt::Display for ProtocolStatistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::TcpInSegs => write!(f, "network/tcp/receive/segments"),
+            Self::TcpOutSegs => write!(f, "network/tcp/transmit/segments"),
+            Self::TcpPruneCalled => write!(f, "network/tcp/receive/prune_called"),
+            Self::TcpRcvCollapsed => write!(f, "network/tcp/receive/collapsed"),
+            Self::TcpRetransSegs => write!(f, "network/tcp/transmit/retranmits"),
+            Self::UdpInDatagrams => write!(f, "network/udp/receive/datagrams"),
+            Self::UdpInErrors => write!(f, "network/udp/receive/errors"),
+            Self::UdpOutDatagrams => write!(f, "network/udp/transmit/datagrams"),
+        }
+    }
+}
+
+impl ProtocolStatistic {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::TcpInSegs => "InSegs",
+            Self::TcpOutSegs => "OutSegs",
+            Self::TcpPruneCalled => "PruneCalled",
+            Self::TcpRcvCollapsed => "TCPRcvCollapsed",
+            Self::TcpRetransSegs => "RetransSegs",
+            Self::UdpInDatagrams => "InDatagrams",
+            Self::UdpInErrors => "InErrors",
+            Self::UdpOutDatagrams => "OutDatagrams",
+        }
+    }
+
+    pub fn protocol(&self) -> &str {
+        match self {
+            Self::TcpInSegs
+            | Self::TcpOutSegs
+            | Self::TcpRetransSegs => "Tcp:",
+            Self::TcpPruneCalled | Self::TcpRcvCollapsed => "TcpExt:",
+            Self::UdpInDatagrams
+            | Self::UdpInErrors
+            | Self::UdpOutDatagrams => "Udp:",
+        }
+    }
+}
+


### PR DESCRIPTION
Refactors the network sampler to move statistic enums into a
`statistics` module'