### PR TITLE
update bcc to 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allows memcache sampler to reconnect to the cache instance which helps to make
   the sampler more resilient to transient errors
 - Softnet sampler now disabled by default to be consistent with other samplers
+- Updates bcc version to pull-in bugfixes
 
 # [1.0.1] - 2019-08-22
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "bcc"
-version = "0.0.11"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bcc-sys 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -654,7 +654,7 @@ name = "rezolus"
 version = "1.0.2-alpha.0"
 dependencies = [
  "atomics 0.3.0 (git+https://github.com/twitter/rpc-perf)",
- "bcc 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bcc 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -994,7 +994,7 @@ dependencies = [
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum bcc 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "296e95ec788e3aa896003c8b810b1731b1703741e406b907e079e21ca1afb0ad"
+"checksum bcc 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "835595d0d0bbf279a3246c0604bf4418769a6539446ff08430e58adcf49f7f83"
 "checksum bcc-sys 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b804c98cce65055fde1b1ac2073ffcca3b31d4abf015605ae0b7c3df6456a024"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = '2018'
 
 [dependencies]
 atomics = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
-bcc = { version = "0.0.11", optional = true }
+bcc = { version = "0.0.12", optional = true }
 clap = "2.33.0"
 failure = "0.1.5"
 json = "0.12.0"


### PR DESCRIPTION
Problem

bcc 0.0.11 has bugs which can result in segfault for some use-cases

Solution

Updates bcc to 0.0.12 to pull-in bugfixes