### PR TITLE
Add `common()` to `Sampler` trait

### DIFF
--- a/src/samplers/container/mod.rs
+++ b/src/samplers/container/mod.rs
@@ -56,6 +56,10 @@ impl<'a> Sampler<'a> for Container<'a> {
         }
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "container".to_string()
     }

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -95,6 +95,11 @@ impl<'a> Sampler<'a> for Cpu<'a> {
             Ok(None)
         }
     }
+
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "cpu".to_string()
     }

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -80,6 +80,10 @@ impl<'a> Sampler<'a> for Disk<'a> {
         }
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "disk".to_string()
     }

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -116,6 +116,10 @@ impl<'a> Sampler<'a> for Block<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "ebpf::block".to_string()
     }

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -62,6 +62,10 @@ impl<'a> Sampler<'a> for Ext4<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "ebpf::ext4".to_string()
     }

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -49,6 +49,10 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "ebpf::scheduler".to_string()
     }

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -59,6 +59,10 @@ impl<'a> Sampler<'a> for Xfs<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "ebpf::xfs".to_string()
     }

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -65,6 +65,10 @@ impl<'a> Sampler<'a> for Memcache<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "memcache".to_string()
     }

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -41,6 +41,9 @@ pub trait Sampler<'a> {
     where
         Self: Sized;
 
+    /// Return a reference to the `Common` struct
+    fn common(&self) -> &Common<'a>;
+
     /// Perform required sampling steps and send stats to the `Recorder`
     fn sample(&mut self) -> Result<(), ()>;
 

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -76,6 +76,10 @@ impl<'a> Sampler<'a> for Network<'a> {
         }
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "network".to_string()
     }

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -62,6 +62,10 @@ impl<'a> Sampler<'a> for Perf<'a> {
         }
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "perf".to_string()
     }

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -150,6 +150,10 @@ impl<'a> Sampler<'a> for Rezolus<'a> {
         })))
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "rezolus".to_string()
     }

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -71,6 +71,10 @@ impl<'a> Sampler<'a> for Softnet<'a> {
         }
     }
 
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
     fn name(&self) -> String {
         "softnet".to_string()
     }


### PR DESCRIPTION
Adds a `common()` function to the definition of the `Sampler` trait
which provides consistent access to the `Common` struct.