### PR TITLE
Use timers to drive sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "atomics"
 version = "0.3.0"
-source = "git+https://github.com/twitter/rpc-perf#f4d4367a2be52418667d01bf39df2fd93e6167a9"
+source = "git+https://github.com/twitter/rpc-perf#0fd697b9c9412701d4026f5829bb2cab605ee165"
 dependencies = [
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "datastructures"
 version = "0.4.0"
-source = "git+https://github.com/twitter/rpc-perf#f4d4367a2be52418667d01bf39df2fd93e6167a9"
+source = "git+https://github.com/twitter/rpc-perf#0fd697b9c9412701d4026f5829bb2cab605ee165"
 dependencies = [
  "atomics 0.3.0 (git+https://github.com/twitter/rpc-perf)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rpc-perf#f4d4367a2be52418667d01bf39df2fd93e6167a9"
+source = "git+https://github.com/twitter/rpc-perf#0fd697b9c9412701d4026f5829bb2cab605ee165"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.4.0"
-source = "git+https://github.com/twitter/rpc-perf#f4d4367a2be52418667d01bf39df2fd93e6167a9"
+source = "git+https://github.com/twitter/rpc-perf#0fd697b9c9412701d4026f5829bb2cab605ee165"
 dependencies = [
  "datastructures 0.4.0 (git+https://github.com/twitter/rpc-perf)",
  "evmap 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,8 +664,10 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sysconf 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "timer 0.1.2 (git+https://github.com/twitter/rpc-perf)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,6 +747,11 @@ dependencies = [
 [[package]]
 name = "siphasher"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -837,6 +844,14 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "timer"
+version = "0.1.2"
+source = "git+https://github.com/twitter/rpc-perf#0fd697b9c9412701d4026f5829bb2cab605ee165"
+dependencies = [
+ "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
 ]
 
 [[package]]
@@ -1075,6 +1090,7 @@ dependencies = [
 "checksum serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "11e410fde43e157d789fc290d26bc940778ad0fdd47836426fbac36573710dbb"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -1086,6 +1102,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum timer 0.1.2 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ perfcnt = { version = "0.5.0", optional = true }
 regex = "1.3.1"
 serde = "1.0.100"
 serde_derive = "1.0.100"
+slab = "0.4.2"
 sysconf = "0.3.4"
 time = "0.1.42"
+timer = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 tiny_http = "0.6.2"
 toml = "0.5.3"
 uuid = "0.7.4"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -134,6 +134,10 @@ impl Config {
         &self.general
     }
 
+    pub fn interval(&self) -> usize {
+        self.general().interval()
+    }
+
     pub fn network(&self) -> &Network {
         &self.network
     }


### PR DESCRIPTION
Converts the main loop to use timers to drive the sampling. This
paves the way for each sampler to have a configurable sampling
interval.