### PR TITLE
allow per-sampler intervals

### DIFF
--- a/src/config/container.rs
+++ b/src/config/container.rs
@@ -11,12 +11,15 @@ use atomics::*;
 pub struct Container {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
 }
 
 impl Default for Container {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
+            interval: default_interval(),
         }
     }
 }
@@ -25,8 +28,16 @@ fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
 }
 
-impl Container {
-    pub fn enabled(&self) -> bool {
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
+impl SamplerConfig for Container {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
     }
 }

--- a/src/config/cpu.rs
+++ b/src/config/cpu.rs
@@ -12,6 +12,8 @@ use atomics::*;
 pub struct Cpu {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
     #[serde(default = "default_statistics")]
     statistics: Vec<Statistic>,
 }
@@ -20,6 +22,7 @@ impl Default for Cpu {
     fn default() -> Cpu {
         Cpu {
             enabled: default_enabled(),
+            interval: default_interval(),
             statistics: default_statistics(),
         }
     }
@@ -29,15 +32,25 @@ fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
 }
 
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
 fn default_statistics() -> Vec<Statistic> {
     vec![Statistic::User, Statistic::System, Statistic::Idle]
 }
 
-impl Cpu {
-    pub fn enabled(&self) -> bool {
+impl SamplerConfig for Cpu {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }
 
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
+    }
+}
+
+impl Cpu {
     pub fn statistics(&self) -> Vec<Statistic> {
         self.statistics.clone()
     }

--- a/src/config/disk.rs
+++ b/src/config/disk.rs
@@ -11,12 +11,15 @@ use atomics::*;
 pub struct Disk {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
 }
 
 impl Default for Disk {
     fn default() -> Disk {
         Disk {
             enabled: default_enabled(),
+            interval: default_interval(),
         }
     }
 }
@@ -25,8 +28,16 @@ fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
 }
 
-impl Disk {
-    pub fn enabled(&self) -> bool {
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
+impl SamplerConfig for Disk {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
     }
 }

--- a/src/config/ebpf.rs
+++ b/src/config/ebpf.rs
@@ -15,6 +15,8 @@ pub struct Ebpf {
     block: AtomicBool,
     #[serde(default = "default")]
     ext4: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
     #[serde(default = "default")]
     scheduler: AtomicBool,
     #[serde(default = "default")]
@@ -27,6 +29,7 @@ impl Default for Ebpf {
             all: default(),
             block: default(),
             ext4: default(),
+            interval: default_interval(),
             scheduler: default(),
             xfs: default(),
         }
@@ -35,6 +38,20 @@ impl Default for Ebpf {
 
 fn default() -> AtomicBool {
     AtomicBool::new(false)
+}
+
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
+impl SamplerConfig for Ebpf {
+    fn enabled(&self) -> bool {
+        self.block() || self.ext4() || self.scheduler() || self.xfs()
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
+    }
 }
 
 impl Ebpf {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -170,3 +170,8 @@ impl Config {
         }
     }
 }
+
+pub trait SamplerConfig {
+    fn enabled(&self) -> bool;
+    fn interval(&self) -> Option<usize>;
+}

--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -14,6 +14,8 @@ pub struct Network {
     enabled: AtomicBool,
     #[serde(default = "default_interface_statistics")]
     interface_statistics: Vec<InterfaceStatistic>,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
     #[serde(default = "default_protocol_statistics")]
     protocol_statistics: Vec<ProtocolStatistic>,
 }
@@ -23,6 +25,7 @@ impl Default for Network {
         Network {
             enabled: default_enabled(),
             interface_statistics: default_interface_statistics(),
+            interval: default_interval(),
             protocol_statistics: default_protocol_statistics(),
         }
     }
@@ -30,6 +33,10 @@ impl Default for Network {
 
 fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
+}
+
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
 }
 
 fn default_interface_statistics() -> Vec<InterfaceStatistic> {
@@ -63,11 +70,17 @@ fn default_protocol_statistics() -> Vec<ProtocolStatistic> {
     ]
 }
 
-impl Network {
-    pub fn enabled(&self) -> bool {
+impl SamplerConfig for Network {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }
 
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
+    }
+}
+
+impl Network {
     pub fn interface_statistics(&self) -> &[InterfaceStatistic] {
         &self.interface_statistics
     }

--- a/src/config/perf.rs
+++ b/src/config/perf.rs
@@ -12,6 +12,8 @@ use atomics::*;
 pub struct Perf {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
     #[serde(default = "default_statistics")]
     statistics: Vec<Statistic>,
 }
@@ -20,6 +22,7 @@ impl Default for Perf {
     fn default() -> Perf {
         Perf {
             enabled: default_enabled(),
+            interval: default_interval(),
             statistics: default_statistics(),
         }
     }
@@ -27,6 +30,10 @@ impl Default for Perf {
 
 fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
+}
+
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
 }
 
 fn default_statistics() -> Vec<Statistic> {
@@ -54,11 +61,17 @@ fn default_statistics() -> Vec<Statistic> {
     ]
 }
 
-impl Perf {
-    pub fn enabled(&self) -> bool {
+impl SamplerConfig for Perf {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }
 
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
+    }
+}
+
+impl Perf {
     pub fn statistics(&self) -> &[Statistic] {
         &self.statistics
     }

--- a/src/config/softnet.rs
+++ b/src/config/softnet.rs
@@ -11,12 +11,15 @@ use atomics::*;
 pub struct Softnet {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
 }
 
 impl Default for Softnet {
     fn default() -> Softnet {
         Softnet {
             enabled: default_enabled(),
+            interval: default_interval(),
         }
     }
 }
@@ -25,8 +28,16 @@ fn default_enabled() -> AtomicBool {
     AtomicBool::new(false)
 }
 
-impl Softnet {
-    pub fn enabled(&self) -> bool {
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
+impl SamplerConfig for Softnet {
+    fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,10 +201,10 @@ fn main() {
                             sampler.deregister();
                         } else {
                             stats.sequential_timeouts = 0;
-                            timer.add(token, config.interval());
+                            timer.add(token, sampler.interval());
                         }
                     } else {
-                        timer.add(token, config.interval());
+                        timer.add(token, sampler.interval());
                     }
                 }
                 Err(_) => {

--- a/src/samplers/container/mod.rs
+++ b/src/samplers/container/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::*;
@@ -54,6 +54,14 @@ impl<'a> Sampler<'a> for Container<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .container()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn common(&self) -> &Common<'a> {

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod statistics;
 
 use self::statistics::*;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -115,6 +115,14 @@ impl<'a> Sampler<'a> for Cpu<'a> {
             self.common.record_counter(&statistic, time, value);
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .cpu()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -11,7 +11,7 @@ pub use self::entry::Entry;
 pub(crate) use self::statistics::Statistic;
 
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -103,6 +103,14 @@ impl<'a> Sampler<'a> for Disk<'a> {
         self.register();
         self.record(time, current.values().sum());
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .disk()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::{Direction, Statistic};
 use crate::common::{BILLION, MICROSECOND, MILLION, PERCENTILES};
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
@@ -140,6 +140,14 @@ impl<'a> Sampler<'a> for Block<'a> {
             self.report_statistic(statistic);
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::{MICROSECOND, PERCENTILES, SECOND};
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
@@ -89,6 +89,14 @@ impl<'a> Sampler<'a> for Ext4<'a> {
             }
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::{MICROSECOND, PERCENTILES, SECOND};
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
@@ -71,6 +71,14 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
             }
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::{MICROSECOND, PERCENTILES, SECOND};
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
@@ -86,6 +86,14 @@ impl<'a> Sampler<'a> for Xfs<'a> {
             }
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -140,6 +140,10 @@ impl<'a> Sampler<'a> for Memcache<'a> {
             self.reconnect();
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common().config().interval()
     }
 
     fn register(&mut self) {

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -33,21 +33,21 @@ use metrics::*;
 /// The `Sampler` will perform the necessary actions to update the telemetry and
 /// record updated values into the metrics `Recorder`
 pub trait Sampler<'a> {
-    fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error>
+    fn new(config: &'a Config, metrics: &'a Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error>
     where
         Self: Sized;
 
     /// Return a reference to the `Common` struct
     fn common(&self) -> &Common<'a>;
 
+    /// Return the name of the `Sampler`
+    fn name(&self) -> String;
+
     /// Perform required sampling steps and send stats to the `Recorder`
     fn sample(&mut self) -> Result<(), ()>;
 
-    /// Return the name of the `Sampler`
-    fn name(&self) -> String;
+    /// Return the current configured interval in milliseconds for the `Sampler`
+    fn interval(&self) -> usize;
 
     /// Register any metrics that the `Sampler` will report
     fn register(&mut self);

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -10,7 +10,7 @@ pub use self::interface::*;
 
 use self::statistics::InterfaceStatistic;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -112,6 +112,14 @@ impl<'a> Sampler<'a> for Network<'a> {
         }
 
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .network()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -6,7 +6,7 @@ pub mod statistics;
 
 use self::statistics::*;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -97,6 +97,14 @@ impl<'a> Sampler<'a> for Perf<'a> {
             }
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .perf()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -6,12 +6,12 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
 use logger::*;
-use metrics::{AtomicU32, Percentile, Metrics};
+use metrics::{AtomicU32, Metrics, Percentile};
 use time;
 
 use std::collections::HashMap;
@@ -164,6 +164,10 @@ impl<'a> Sampler<'a> for Rezolus<'a> {
         self.memory_usage();
         self.cpu_usage();
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common().config().interval()
     }
 
     fn register(&mut self) {

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use crate::common::*;
-use crate::config::Config;
+use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use failure::Error;
@@ -88,6 +88,14 @@ impl<'a> Sampler<'a> for Softnet<'a> {
             self.common.record_counter(&statistic, time, value);
         }
         Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .softnet()
+            .interval()
+            .unwrap_or(self.common().config().interval())
     }
 
     fn register(&mut self) {


### PR DESCRIPTION
Defines a `SamplerConfig` trait to help unify individual sampler
configuration. Adds an optional interval field to each sampler
config section so that it can be overridden on a per-sampler basis.

Extends the `Sampler` trait so that each `Sampler` can provide the
currently configured interval for that `Sampler`.