### PR TITLE
bugfix: network sampling

### DIFF
--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -43,10 +43,6 @@ impl<'a> Network<'a> {
                     trace!("Ignore NIC: bad prefix: {}", name);
                     continue;
                 }
-                if !net::is_nic_active(name) {
-                    trace!("Ignore NIC: inactive: {}", name);
-                    continue;
-                }
                 if let Ok(speed) = file::file_as_u64(format!("/sys/class/net/{}/speed", name)) {
                     trace!("Monitoring NIC: {} speed: {} mbps", name, speed);
                     let bytes_secondly = (speed * 1_000_000) / 8;


### PR DESCRIPTION
Problem

The check for whether a NIC is active or not can improperly mark
the active NIC as inactive when the operstate is `unknown`. This
can result in all NICs being marked as inactive, which then causes
the calculated host bandwidth to be zero. In this case, the max for
the histograms is then set to zero, resulting in improper
percentiles for network stats.


Solution

This PR removes the NIC active check, which results in the speed of
all NICs (including those which are down or unknown) contributing
to the max bandwidth of the host. This is likely better for
environments in which NICs may be brought online after Rezolus is
already running.
