### PR TITLE
bugfix: avoid panics in eBPF samplers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,6 @@ matrix:
       rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - rustup component add clippy --toolchain nightly
-        - cargo +nightly clippy
+        - rustup toolchain install nightly-2019-10-04
+        - rustup component add clippy --toolchain nightly-2019-10-04
+        - cargo +nightly-2019-10-04 clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ os: linux
 dist: xenial
 sudo: required
 matrix:
-  allow_failures:
-    - env: TYPE=rustfmt RUST_BACKTRACE=1
-    - env: TYPE=clippy RUST_BACKTRACE=1
   fast_finish: true
   include:
     - os: linux
@@ -56,4 +53,4 @@ matrix:
       script:
         - rustup toolchain install nightly-2019-10-04
         - rustup component add clippy --toolchain nightly-2019-10-04
-        - cargo +nightly-2019-10-04 clippy
+        - cargo +nightly-2019-10-04 clippy --features ebpf

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
         - cargo test --verbose
         - cargo build --release --verbose
         - cargo test --release --verbose
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
     - os: linux
       rust: nightly
       env: TYPE=ebpf RUST_BACKTRACE=1
@@ -42,15 +43,16 @@ matrix:
         - cargo build --release --features ebpf
         - cargo test --release --features ebpf
         - cargo run --release --features ebpf -- --version
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
     - os: linux
-      rust: nightly
+      rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1
       script:
-        - rustup component add rustfmt
-        - cargo fmt -- --check
+        - rustup component add rustfmt --toolchain stable
+        - cargo +stable fmt -- --check
     - os: linux
-      rust: nightly
+      rust: stable
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - rustup component add clippy
-        - cargo clippy
+        - rustup component add clippy --toolchain stable
+        - cargo +stable clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ matrix:
         - rustup component add rustfmt --toolchain stable
         - cargo +stable fmt -- --check
     - os: linux
-      rust: stable
+      rust: nightly
       env: TYPE=clippy RUST_BACKTRACE=1
       script:
-        - rustup component add clippy --toolchain stable
-        - cargo +stable clippy
+        - rustup component add clippy --toolchain nightly
+        - cargo +nightly clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "datastructures"
 version = "0.4.0"
 source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
@@ -337,6 +346,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -644,6 +665,7 @@ dependencies = [
  "atomics 0.3.0 (git+https://github.com/twitter/rpc-perf)",
  "bcc 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
@@ -924,6 +946,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1032,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum datastructures 0.4.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
@@ -1027,6 +1055,7 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum metrics 0.4.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -1095,6 +1124,7 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = '2018'
 atomics = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 bcc = { version = "0.0.12", optional = true }
 clap = "2.33.0"
+ctrlc = "3.1.3"
 failure = "0.1.5"
 json = "0.12.0"
 logger = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
@@ -31,7 +32,7 @@ walkdir = "2.2.9"
 vergen = "3.0.4"
 
 [features]
-default = ["perf"]
+default = ["ctrlc/termination", "perf"]
 ebpf = ["bcc"]
 ebpf_static = ["ebpf", "bcc/static"]
 ebpf_v0_5_0 = ["ebpf", "bcc/v0_5_0"]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -48,6 +48,7 @@ pub const CONTAINER_REFRESH: u64 = MINUTE;
 pub const HTTP_TIMEOUT: u64 = 500 * MILLISECOND;
 pub const POLL_DELAY: u64 = 50 * MILLISECOND;
 pub const SECTOR_SIZE: u64 = 512; //bytes per sector
+pub const UNITY: u64 = 1;
 
 // reported percentiles
 pub const PERCENTILES: &[Percentile] = &[

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,7 @@ use std::io::Read;
 use std::net::{SocketAddr, ToSocketAddrs};
 
 use clap::{App, Arg};
+use logger::Level;
 use serde_derive::*;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+#![deny(clippy::all)]
+
 #[macro_use]
 extern crate logger;
 
@@ -36,6 +38,7 @@ impl Default for Stats {
     }
 }
 
+#[allow(clippy::cognitive_complexity)]
 fn main() {
     // get config
     let config = Config::new();
@@ -185,8 +188,8 @@ fn main() {
 
     while runnable.load(Ordering::Relaxed) {
         let t1 = time::precise_time_ns();
-        let ticks = (t1 - t0) / 1000000;
-        t0 += ticks * 1000000;
+        let ticks = (t1 - t0) / MILLISECOND;
+        t0 += ticks * MILLISECOND;
         let to_sample = timer.tick(ticks as usize);
         trace!(
             "ticked: {} ms and sampling: {} samplers",

--- a/src/samplers/container/mod.rs
+++ b/src/samplers/container/mod.rs
@@ -36,10 +36,8 @@ impl<'a> Sampler<'a> for Container<'a> {
             for line in f.lines() {
                 let line = line.unwrap();
                 let parts: Vec<&str> = line.split(':').collect();
-                if parts.len() == 3 {
-                    if parts[1] == "cpu,cpuacct" {
-                        cgroup = Some(parts[2].to_string());
-                    }
+                if parts.len() == 3 && parts[1] == "cpu,cpuacct" {
+                    cgroup = Some(parts[2].to_string());
                 }
             }
             if cgroup.is_some() {
@@ -61,7 +59,7 @@ impl<'a> Sampler<'a> for Container<'a> {
             .config()
             .container()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn common(&self) -> &Common<'a> {

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -122,7 +122,7 @@ impl<'a> Sampler<'a> for Cpu<'a> {
             .config()
             .cpu()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -110,7 +110,7 @@ impl<'a> Sampler<'a> for Disk<'a> {
             .config()
             .disk()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -114,7 +114,7 @@ impl<'a> Sampler<'a> for Block<'a> {
             .config()
             .ebpf()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -5,7 +5,8 @@
 mod statistics;
 
 use self::statistics::{Direction, Statistic};
-use crate::common::{BILLION, MICROSECOND, MILLION, PERCENTILES};
+use super::map_from_table;
+use crate::common::{BILLION, MICROSECOND, MILLION, PERCENTILES, UNITY};
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
@@ -15,8 +16,6 @@ use failure::*;
 use logger::*;
 use metrics::*;
 use time;
-
-use std::collections::HashMap;
 
 pub struct Block<'a> {
     bpf: BPF,
@@ -37,54 +36,22 @@ impl<'a> Block<'a> {
 
     fn report_latency(&mut self, table: &str, label: &str) {
         let time = time::precise_time_ns();
-        let mut current = HashMap::new();
-        let mut data = self.bpf.table(table);
+        let mut table = self.bpf.table(table);
 
-        for mut entry in data.iter() {
-            let mut key = [0; 4];
-            key.copy_from_slice(&entry.key);
-            let key = u32::from_ne_bytes(key);
-
-            let mut value = [0; 8];
-            value.copy_from_slice(&entry.value);
-            let value = u64::from_ne_bytes(value);
-
-            if let Some(key) = super::key_to_value(key as u64) {
-                current.insert(key * MICROSECOND, value as u32);
-            }
-
-            // clear the source counter
-            let _ = data.set(&mut entry.key, &mut [0_u8; 8]);
-        }
         self.register();
-        for (&value, &count) in &current {
+
+        for (&value, &count) in &map_from_table(&mut table, MICROSECOND) {
             self.common.record_distribution(&label, time, value, count);
         }
     }
 
     fn report_size(&mut self, table: &str, label: &str) {
         let time = time::precise_time_ns();
-        let mut current = HashMap::new();
-        let mut data = self.bpf.table(table);
+        let mut table = self.bpf.table(table);
 
-        for mut entry in data.iter() {
-            let mut key = [0; 4];
-            key.copy_from_slice(&entry.key);
-            let key = u32::from_ne_bytes(key);
-
-            let mut value = [0; 8];
-            value.copy_from_slice(&entry.value);
-            let value = u64::from_ne_bytes(value);
-
-            if let Some(key) = super::key_to_value(key as u64) {
-                current.insert(key, value as u32);
-            }
-
-            // clear the source counter
-            let _ = data.set(&mut entry.key, &mut [0_u8; 8]);
-        }
         self.register();
-        for (&value, &count) in &current {
+
+        for (&value, &count) in &map_from_table(&mut table, UNITY) {
             self.common.record_distribution(&label, time, value, count);
         }
     }

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Sampler<'a> for Ext4<'a> {
             .config()
             .ebpf()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -5,19 +5,17 @@
 mod statistics;
 
 use self::statistics::Statistic;
+use super::map_from_table;
 use crate::common::{MICROSECOND, PERCENTILES, SECOND};
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
 use bcc::core::BPF;
-use bcc::table::Table;
 use failure::*;
 use logger::*;
 use metrics::*;
 use time;
-
-use std::collections::HashMap;
 
 pub struct Ext4<'a> {
     bpf: BPF,
@@ -83,7 +81,7 @@ impl<'a> Sampler<'a> for Ext4<'a> {
         ] {
             trace!("sampling {}", statistic);
             let mut table = self.bpf.table(&statistic.table_name());
-            for (&value, &count) in &map_from_table(&mut table) {
+            for (&value, &count) in &map_from_table(&mut table, MICROSECOND) {
                 self.common
                     .record_distribution(statistic, time, value, count);
             }
@@ -129,27 +127,4 @@ impl<'a> Sampler<'a> for Ext4<'a> {
             self.common.set_initialized(false);
         }
     }
-}
-
-fn map_from_table(table: &mut Table) -> HashMap<u64, u32> {
-    let mut current = HashMap::new();
-
-    trace!("transferring data to userspace");
-    for mut entry in table.iter() {
-        let mut key = [0; 4];
-        key.copy_from_slice(&entry.key);
-        let key = u32::from_ne_bytes(key);
-
-        let mut value = [0; 8];
-        value.copy_from_slice(&entry.value);
-        let value = u64::from_ne_bytes(value);
-
-        if let Some(key) = super::key_to_value(key as u64) {
-            current.insert(key * MICROSECOND, value as u32);
-        }
-
-        // clear the source counter
-        let _ = table.set(&mut entry.key, &mut [0_u8; 8]);
-    }
-    current
 }

--- a/src/samplers/ebpf/mod.rs
+++ b/src/samplers/ebpf/mod.rs
@@ -12,6 +12,9 @@ pub use self::ext4::Ext4;
 pub use self::scheduler::Scheduler;
 pub use self::xfs::Xfs;
 
+use bcc::table::Table;
+
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -51,6 +54,47 @@ pub fn symbol_lookup(name: &str) -> Option<String> {
     }
 
     None
+}
+
+pub fn map_from_table(table: &mut Table, key_scale: u64) -> HashMap<u64, u32> {
+    let mut current = HashMap::new();
+
+    trace!("transferring data to userspace");
+    for (id, mut entry) in table.iter().enumerate() {
+        let mut key = [0; 4];
+        if key.len() != entry.key.len() {
+            // log and skip processing if the key length is unexpected
+            debug!(
+                "unexpected length of the entry's key, entry id: {} key length: {}",
+                id,
+                entry.key.len()
+            );
+            continue;
+        }
+        key.copy_from_slice(&entry.key);
+        let key = u32::from_ne_bytes(key);
+
+        let mut value = [0; 8];
+        if value.len() != entry.value.len() {
+            // log and skip processing if the value length is unexpected
+            debug!(
+                "unexpected length of the entry's value, entry id: {} value length: {}",
+                id,
+                entry.value.len()
+            );
+            continue;
+        }
+        value.copy_from_slice(&entry.value);
+        let value = u64::from_ne_bytes(value);
+
+        if let Some(key) = key_to_value(key as u64) {
+            current.insert(key * key_scale, value as u32);
+        }
+
+        // clear the source counter
+        let _ = table.set(&mut entry.key, &mut [0_u8; 8]);
+    }
+    current
 }
 
 #[cfg(test)]

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -76,7 +76,7 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
             .config()
             .ebpf()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -5,19 +5,17 @@
 mod statistics;
 
 use self::statistics::Statistic;
+use super::map_from_table;
 use crate::common::{MICROSECOND, PERCENTILES, SECOND};
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
 use bcc;
 use bcc::core::BPF;
-use bcc::table::Table;
 use failure::*;
 use logger::*;
 use metrics::*;
 use time;
-
-use std::collections::HashMap;
 
 pub struct Scheduler<'a> {
     bpf: BPF,
@@ -65,7 +63,7 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
         for statistic in &[Statistic::RunqueueLatency] {
             trace!("sampling {}", statistic);
             let mut table = self.bpf.table(&statistic.table_name());
-            for (&value, &count) in &map_from_table(&mut table) {
+            for (&value, &count) in &map_from_table(&mut table, MICROSECOND) {
                 self.common
                     .record_distribution(statistic, time, value, count);
             }
@@ -97,27 +95,4 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
             self.common.set_initialized(false);
         }
     }
-}
-
-fn map_from_table(table: &mut Table) -> HashMap<u64, u32> {
-    let mut current = HashMap::new();
-
-    trace!("transferring data to userspace");
-    for mut entry in table.iter() {
-        let mut key = [0; 4];
-        key.copy_from_slice(&entry.key);
-        let key = u32::from_ne_bytes(key);
-
-        let mut value = [0; 8];
-        value.copy_from_slice(&entry.value);
-        let value = u64::from_ne_bytes(value);
-
-        if let Some(key) = super::key_to_value(key as u64) {
-            current.insert(key * MICROSECOND, value as u32);
-        }
-
-        // clear the source counter
-        let _ = table.set(&mut entry.key, &mut [0_u8; 8]);
-    }
-    current
 }

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -91,7 +91,7 @@ impl<'a> Sampler<'a> for Xfs<'a> {
             .config()
             .ebpf()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -91,6 +91,7 @@ impl<'a> Common<'a> {
         self.metrics.delete_channel(name.to_string())
     }
 
+    #[allow(dead_code)]
     pub fn record_distribution(&self, label: &dyn ToString, time: u64, value: u64, count: u32) {
         self.metrics.record(
             label.to_string(),
@@ -108,6 +109,7 @@ impl<'a> Common<'a> {
             .record(label.to_string(), Measurement::Gauge { time, value });
     }
 
+    #[allow(dead_code)]
     pub fn register_distribution(
         &self,
         label: &dyn ToString,

--- a/src/samplers/network/interface.rs
+++ b/src/samplers/network/interface.rs
@@ -38,7 +38,7 @@ impl Interface {
         self.bandwidth_bytes
     }
 
-    pub fn get_statistic(&self, statistic: &InterfaceStatistic) -> Result<u64, ()> {
+    pub fn get_statistic(&self, statistic: InterfaceStatistic) -> Result<u64, ()> {
         if let Some(name) = &self.name {
             net::read_network_stat(&name, statistic.name())
         } else {

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Sampler<'a> for Network<'a> {
             let sum: u64 = self
                 .interfaces
                 .iter()
-                .map(|i| i.get_statistic(&statistic).unwrap_or(0))
+                .map(|i| i.get_statistic(*statistic).unwrap_or(0))
                 .sum();
             self.common.record_counter(&statistic, time, sum);
         }
@@ -102,7 +102,7 @@ impl<'a> Sampler<'a> for Network<'a> {
         // protocol statistics
         if let Ok(protocol) = protocol::Protocol::new() {
             for statistic in self.common.config().network().protocol_statistics() {
-                let value = *protocol.get(statistic).unwrap_or(&0);
+                let value = *protocol.get(*statistic).unwrap_or(&0);
                 self.common.record_counter(statistic, time, value);
             }
         }
@@ -115,7 +115,7 @@ impl<'a> Sampler<'a> for Network<'a> {
             .config()
             .network()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/network/protocol.rs
+++ b/src/samplers/network/protocol.rs
@@ -19,7 +19,7 @@ impl Protocol {
         Ok(Self { data })
     }
 
-    pub fn get(&self, statistic: &ProtocolStatistic) -> Option<&u64> {
+    pub fn get(&self, statistic: ProtocolStatistic) -> Option<&u64> {
         if let Some(inner) = self.data.get(statistic.protocol()) {
             inner.get(statistic.name())
         } else {

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -104,7 +104,7 @@ impl<'a> Sampler<'a> for Perf<'a> {
             .config()
             .perf()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -95,7 +95,7 @@ impl<'a> Sampler<'a> for Softnet<'a> {
             .config()
             .softnet()
             .interval()
-            .unwrap_or(self.common().config().interval())
+            .unwrap_or_else(|| self.common().config().interval())
     }
 
     fn register(&mut self) {

--- a/src/samplers/softnet/statistics.rs
+++ b/src/samplers/softnet/statistics.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for Statistic {
 }
 
 impl Statistic {
-    pub fn field_number(&self) -> usize {
+    pub fn field_number(self) -> usize {
         match self {
             Statistic::Processed => 0,
             Statistic::Dropped => 1,


### PR DESCRIPTION
Attempts to avoid panics in eBPF samplers by checking the slice
lengths before using `copy_from_slice()`. Refactors the eBPF
samplers to use a common function to get the data from the `Table`.

Problem

The `copy_from_slice()` function is used when transferring data from
kernel space to user space in the eBPF samplers. This function will
panic if the slices are not the same length.

Solution

Create a common function to transfer the data from the BPF `Table`
into the userspace map which checks the slice length before calling
the function.

Result

We will print an error message instead of panicing.
