### PR TITLE
add TCP Connect Latency via eBPF

### DIFF
--- a/src/config/ebpf.rs
+++ b/src/config/ebpf.rs
@@ -20,6 +20,8 @@ pub struct Ebpf {
     #[serde(default = "default")]
     scheduler: AtomicBool,
     #[serde(default = "default")]
+    tcp: AtomicBool,
+    #[serde(default = "default")]
     xfs: AtomicBool,
 }
 
@@ -31,6 +33,7 @@ impl Default for Ebpf {
             ext4: default(),
             interval: default_interval(),
             scheduler: default(),
+            tcp: default(),
             xfs: default(),
         }
     }
@@ -46,7 +49,7 @@ fn default_interval() -> AtomicOption<AtomicUsize> {
 
 impl SamplerConfig for Ebpf {
     fn enabled(&self) -> bool {
-        self.block() || self.ext4() || self.scheduler() || self.xfs()
+        self.block() || self.ext4() || self.scheduler() || self.tcp() || self.xfs()
     }
 
     fn interval(&self) -> Option<usize> {
@@ -68,6 +71,11 @@ impl Ebpf {
     #[allow(dead_code)]
     pub fn scheduler(&self) -> bool {
         self.all.load(Ordering::Relaxed) || self.scheduler.load(Ordering::Relaxed)
+    }
+
+    #[allow(dead_code)]
+    pub fn tcp(&self) -> bool {
+        self.all.load(Ordering::Relaxed) || self.tcp.load(Ordering::Relaxed)
     }
 
     #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,12 @@ fn main() {
                     timer.add(token, config.interval());
                 }
             }
+            if config.ebpf().tcp() {
+                if let Ok(Some(s)) = ebpf::Tcp::new(&config, &metrics) {
+                    let token = samplers.insert((s, Stats::default()));
+                    timer.add(token, config.interval());
+                }
+            }
             if config.ebpf().xfs() {
                 if let Ok(Some(s)) = ebpf::Xfs::new(&config, &metrics) {
                     let token = samplers.insert((s, Stats::default()));

--- a/src/samplers/ebpf/mod.rs
+++ b/src/samplers/ebpf/mod.rs
@@ -5,11 +5,13 @@
 mod block;
 mod ext4;
 mod scheduler;
+mod tcp;
 mod xfs;
 
 pub use self::block::Block;
 pub use self::ext4::Ext4;
 pub use self::scheduler::Scheduler;
+pub use self::tcp::Tcp;
 pub use self::xfs::Xfs;
 
 use bcc::table::Table;

--- a/src/samplers/ebpf/tcp/bpf.c
+++ b/src/samplers/ebpf/tcp/bpf.c
@@ -1,0 +1,84 @@
+// Based on: https://github.com/iovisor/bcc/blob/master/tools/tcpconnlat.py
+
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <net/tcp_states.h>
+#include <bcc/proto.h>
+
+struct info_t {
+    u64 ts;
+    u32 pid;
+    char task[TASK_COMM_LEN];
+};
+
+BPF_HASH(start, struct sock *, struct info_t);
+
+BPF_HISTOGRAM(connlat, int, 461);
+
+// histogram indexing
+static unsigned int value_to_index2(unsigned int value) {
+    unsigned int index = 460;
+    if (value < 100) {
+        // 0-99 => [0..100)
+        // 0 => 0
+        // 99 => 99
+        index = value;
+    } else if (value < 1000) {
+        // 100-999 => [100..190)
+        // 100 => 100
+        // 999 => 189
+        index = 90 + value / 10;
+    } else if (value < 10000) {
+        // 1_000-9_999 => [190..280)
+        // 1000 => 190
+        // 9999 => 279
+        index = 180 + value / 100;
+    } else if (value < 100000) {
+        // 10_000-99_999 => [280..370)
+        // 10000 => 280
+        // 99999 => 369
+        index = 270 + value / 1000;
+    } else if (value < 1000000) {
+        // 100_000-999_999 => [370..460)
+        // 100000 => 370
+        // 999999 => 459
+        index = 360 + value / 10000;
+    } else {
+        index = 460;
+    }
+    return index;
+}
+
+int trace_connect(struct pt_regs *ctx, struct sock *sk)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    struct info_t info = {.pid = pid};
+    info.ts = bpf_ktime_get_ns();
+    bpf_get_current_comm(&info.task, sizeof(info.task));
+    start.update(&sk, &info);
+    return 0;
+};
+
+// See tcp_v4_do_rcv() and tcp_v6_do_rcv(). So TCP_ESTBALISHED and TCP_LISTEN
+// are fast path and processed elsewhere, and leftovers are processed by
+// tcp_rcv_state_process(). We can trace this for handshake completion.
+// This should all be switched to static tracepoints when available.
+int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
+{
+    // will be in TCP_SYN_SENT for handshake
+    if (skp->__sk_common.skc_state != TCP_SYN_SENT)
+        return 0;
+    // check start and calculate delta
+    struct info_t *infop = start.lookup(&skp);
+    if (infop == 0) {
+        return 0;   // missed entry or filtered
+    }
+    u64 ts = infop->ts;
+    u64 now = bpf_ktime_get_ns();
+    u64 delta_us = (now - ts) / 1000ul;
+    u64 index = value_to_index2(delta_us);
+    connlat.increment(index);
+
+    start.delete(&skp);
+    return 0;
+}

--- a/src/samplers/ebpf/tcp/mod.rs
+++ b/src/samplers/ebpf/tcp/mod.rs
@@ -1,0 +1,102 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod statistics;
+
+use self::statistics::Statistic;
+use super::map_from_table;
+use crate::common::{MICROSECOND, PERCENTILES, SECOND};
+use crate::config::*;
+use crate::samplers::{Common, Sampler};
+
+use bcc;
+use bcc::core::BPF;
+use failure::*;
+use logger::*;
+use metrics::*;
+use time;
+
+pub struct Tcp<'a> {
+    bpf: BPF,
+    common: Common<'a>,
+}
+
+impl<'a> Sampler<'a> for Tcp<'a> {
+    fn new(
+        config: &'a Config,
+        metrics: &'a Metrics<AtomicU32>,
+    ) -> Result<Option<Box<Self>>, Error> {
+        debug!("initializing");
+        // load the code and compile
+        let code = include_str!("bpf.c").to_string();
+        let mut bpf = BPF::new(&code)?;
+
+        // load + attach kprobes!
+        let tcp_v4_connect = bpf.load_kprobe("trace_connect")?;
+        let tcp_v6_connect = bpf.load_kprobe("trace_connect")?;
+        let tcp_rcv_state_process = bpf.load_kprobe("trace_tcp_rcv_state_process")?;
+
+        bpf.attach_kprobe("tcp_v4_connect", tcp_v4_connect)?;
+        bpf.attach_kprobe("tcp_v6_connect", tcp_v6_connect)?;
+        bpf.attach_kprobe("tcp_rcv_state_process", tcp_rcv_state_process)?;
+
+        Ok(Some(Box::new(Self {
+            bpf,
+            common: Common::new(config, metrics),
+        })))
+    }
+
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
+    fn name(&self) -> String {
+        "ebpf::tcp".to_string()
+    }
+
+    fn sample(&mut self) -> Result<(), ()> {
+        // gather current state
+        trace!("sampling {}", self.name());
+        let time = time::precise_time_ns();
+        self.register();
+        for statistic in &[Statistic::ConnectLatency] {
+            trace!("sampling {}", statistic);
+            let mut table = self.bpf.table(&statistic.table_name());
+            for (&value, &count) in &map_from_table(&mut table, MICROSECOND) {
+                self.common
+                    .record_distribution(statistic, time, value, count);
+            }
+        }
+        Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or_else(|| self.common().config().interval())
+    }
+
+    fn register(&mut self) {
+        if !self.common.initialized() {
+            trace!("register {}", self.name());
+            for statistic in &[Statistic::ConnectLatency] {
+                self.common
+                    .register_distribution(statistic, SECOND, 2, PERCENTILES);
+            }
+            self.common.set_initialized(true);
+        }
+    }
+
+    fn deregister(&mut self) {
+        if self.common.initialized() {
+            trace!("deregister {}", self.name());
+            for statistic in &[Statistic::ConnectLatency] {
+                self.common.delete_channel(statistic);
+            }
+            self.common.set_initialized(false);
+        }
+    }
+}

--- a/src/samplers/ebpf/tcp/statistics.rs
+++ b/src/samplers/ebpf/tcp/statistics.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub enum Statistic {
+    ConnectLatency,
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::ConnectLatency => write!(f, "network/tcp/connect/latency"),
+        }
+    }
+}
+
+impl Statistic {
+    pub fn table_name(&self) -> String {
+        match self {
+            Self::ConnectLatency => "connlat".to_string(),
+        }
+    }
+}


### PR DESCRIPTION
Adds a new eBPF sampler based on the tcpconnlat example in the
upstream bcc repository. This sampler will report out the latency
for active TCP Connect calls. Fixes #58 
