### PR TITLE
simplify deregister function for all samplers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "atomics"
 version = "0.3.0"
-source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
+source = "git+https://github.com/twitter/rpc-perf#3b26cde9f319428787615d83a2413f96cbd5ec40"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -181,7 +181,7 @@ dependencies = [
 [[package]]
 name = "datastructures"
 version = "0.4.0"
-source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
+source = "git+https://github.com/twitter/rpc-perf#3b26cde9f319428787615d83a2413f96cbd5ec40"
 dependencies = [
  "atomics 0.3.0 (git+https://github.com/twitter/rpc-perf)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
+source = "git+https://github.com/twitter/rpc-perf#3b26cde9f319428787615d83a2413f96cbd5ec40"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -330,8 +330,8 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.0"
-source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
+version = "0.4.1"
+source = "git+https://github.com/twitter/rpc-perf#3b26cde9f319428787615d83a2413f96cbd5ec40"
 dependencies = [
  "datastructures 0.4.0 (git+https://github.com/twitter/rpc-perf)",
  "evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -669,7 +669,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
- "metrics 0.4.0 (git+https://github.com/twitter/rpc-perf)",
+ "metrics 0.4.1 (git+https://github.com/twitter/rpc-perf)",
  "perfcnt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "timer"
 version = "0.1.2"
-source = "git+https://github.com/twitter/rpc-perf#8810bb31f0ed270b8084a42c2f3b6ca07eb99b9f"
+source = "git+https://github.com/twitter/rpc-perf#3b26cde9f319428787615d83a2413f96cbd5ec40"
 dependencies = [
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
 ]
@@ -1053,7 +1053,7 @@ dependencies = [
 "checksum logger 0.1.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum metrics 0.4.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
+"checksum metrics 0.4.1 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"

--- a/src/samplers/container/mod.rs
+++ b/src/samplers/container/mod.rs
@@ -134,15 +134,13 @@ impl<'a> Sampler<'a> for Container<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            for statistic in &[
-                Statistic::CpuSystem,
-                Statistic::CpuTotal,
-                Statistic::CpuUser,
-            ] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        for statistic in &[
+            Statistic::CpuSystem,
+            Statistic::CpuTotal,
+            Statistic::CpuUser,
+        ] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -141,12 +141,10 @@ impl<'a> Sampler<'a> for Cpu<'a> {
 
     fn deregister(&mut self) {
         trace!("deregister {}", self.name());
-        if self.common.initialized() {
-            for statistic in self.common.config().cpu().statistics() {
-                self.common.delete_channel(&statistic);
-            }
-            self.common.set_initialized(false);
+        for statistic in self.common.config().cpu().statistics() {
+            self.common.delete_channel(&statistic);
         }
+        self.common.set_initialized(false);
     }
 }
 

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -131,17 +131,15 @@ impl<'a> Sampler<'a> for Disk<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in &[
-                Statistic::BandwidthRead,
-                Statistic::BandwidthWrite,
-                Statistic::OperationsRead,
-                Statistic::OperationsWrite,
-            ] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in &[
+            Statistic::BandwidthRead,
+            Statistic::BandwidthWrite,
+            Statistic::OperationsRead,
+            Statistic::OperationsWrite,
+        ] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -147,21 +147,19 @@ impl<'a> Sampler<'a> for Block<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in &[
-                Statistic::Size(Direction::Read),
-                Statistic::Size(Direction::Write),
-                Statistic::Latency(Direction::Read),
-                Statistic::Latency(Direction::Write),
-                Statistic::DeviceLatency(Direction::Read),
-                Statistic::DeviceLatency(Direction::Write),
-                Statistic::QueueLatency(Direction::Read),
-                Statistic::QueueLatency(Direction::Write),
-            ] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in &[
+            Statistic::Size(Direction::Read),
+            Statistic::Size(Direction::Write),
+            Statistic::Latency(Direction::Read),
+            Statistic::Latency(Direction::Write),
+            Statistic::DeviceLatency(Direction::Read),
+            Statistic::DeviceLatency(Direction::Write),
+            Statistic::QueueLatency(Direction::Read),
+            Statistic::QueueLatency(Direction::Write),
+        ] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -114,17 +114,15 @@ impl<'a> Sampler<'a> for Ext4<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in &[
-                Statistic::Fsync,
-                Statistic::Open,
-                Statistic::Read,
-                Statistic::Write,
-            ] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in &[
+            Statistic::Fsync,
+            Statistic::Open,
+            Statistic::Read,
+            Statistic::Write,
+        ] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -90,9 +90,7 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
 
     fn deregister(&mut self) {
         debug!("deregister {}", self.name());
-        if self.common.initialized() {
-            self.common.delete_channel(&Statistic::RunqueueLatency);
-            self.common.set_initialized(false);
-        }
+        self.common.delete_channel(&Statistic::RunqueueLatency);
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/ebpf/tcp/mod.rs
+++ b/src/samplers/ebpf/tcp/mod.rs
@@ -91,12 +91,10 @@ impl<'a> Sampler<'a> for Tcp<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in &[Statistic::ConnectLatency] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in &[Statistic::ConnectLatency] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -111,17 +111,15 @@ impl<'a> Sampler<'a> for Xfs<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in &[
-                Statistic::Fsync,
-                Statistic::Open,
-                Statistic::Read,
-                Statistic::Write,
-            ] {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in &[
+            Statistic::Fsync,
+            Statistic::Open,
+            Statistic::Read,
+            Statistic::Write,
+        ] {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -148,15 +148,13 @@ impl<'a> Sampler<'a> for Network<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in self.common.config().network().interface_statistics() {
-                self.common.delete_channel(statistic);
-            }
-            for statistic in self.common.config().network().protocol_statistics() {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in self.common.config().network().interface_statistics() {
+            self.common.delete_channel(statistic);
         }
+        for statistic in self.common.config().network().protocol_statistics() {
+            self.common.delete_channel(statistic);
+        }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -119,12 +119,10 @@ impl<'a> Sampler<'a> for Perf<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for statistic in self.counters.keys() {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for statistic in self.counters.keys() {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -186,16 +186,14 @@ impl<'a> Sampler<'a> for Rezolus<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            for label in self.gauges() {
-                self.common.delete_channel(&label);
-            }
-            for label in self.counters() {
-                self.common.delete_channel(&label);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        for label in self.gauges() {
+            self.common.delete_channel(&label);
         }
+        for label in self.counters() {
+            self.common.delete_channel(&label);
+        }
+        self.common.set_initialized(false);
     }
 }
 

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -111,14 +111,12 @@ impl<'a> Sampler<'a> for Softnet<'a> {
     }
 
     fn deregister(&mut self) {
-        if self.common.initialized() {
-            trace!("deregister {}", self.name());
-            let data = read_softnet_stat(SOFTNET_STAT);
-            for statistic in data.keys() {
-                self.common.delete_channel(statistic);
-            }
-            self.common.set_initialized(false);
+        trace!("deregister {}", self.name());
+        let data = read_softnet_stat(SOFTNET_STAT);
+        for statistic in data.keys() {
+            self.common.delete_channel(statistic);
         }
+        self.common.set_initialized(false);
     }
 }
 


### PR DESCRIPTION
Updates metrics dependency and fixes #62 by simplifying the
deregister function foe all samplers. The check becomes unnecessary
as the metrics library now handles checking if there is a channel
for the metric before taking a lock and removing it.
