### PR TITLE
Add cpuidle sampler

### DIFF
--- a/configs/example.toml
+++ b/configs/example.toml
@@ -31,7 +31,8 @@ enabled = true
 # see docs/METRICS.md for a list of statistics that can be configured 
 statistics = ["user", "system", "idle", "irq", "softirq"]
 
-
+[cpuidle]
+enabled = true
 
 # settings for basic disk telemetry
 [disk]

--- a/src/config/cpuidle.rs
+++ b/src/config/cpuidle.rs
@@ -1,0 +1,62 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::config::*;
+use crate::samplers::cpuidle::statistics::*;
+
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CpuIdle {
+    #[serde(default = "default_enabled")]
+    enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicOption<AtomicUsize>,
+    #[serde(default = "default_statistics")]
+    statistics: Vec<Statistic>,
+}
+
+impl Default for CpuIdle {
+    fn default() -> CpuIdle {
+        CpuIdle {
+            enabled: default_enabled(),
+            interval: default_interval(),
+            statistics: default_statistics(),
+        }
+    }
+}
+
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
+}
+
+fn default_interval() -> AtomicOption<AtomicUsize> {
+    AtomicOption::none()
+}
+
+fn default_statistics() -> Vec<Statistic> {
+    vec![
+        Statistic::State0,
+        Statistic::State1,
+        Statistic::State2,
+        Statistic::State3,
+    ]
+}
+
+impl SamplerConfig for CpuIdle {
+    fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.load(Ordering::Relaxed)
+    }
+}
+
+impl CpuIdle {
+    pub fn statistics(&self) -> Vec<Statistic> {
+        self.statistics.clone()
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@
 
 mod container;
 mod cpu;
+mod cpuidle;
 mod disk;
 mod ebpf;
 mod general;
@@ -13,6 +14,7 @@ mod softnet;
 
 use self::container::Container;
 use self::cpu::Cpu;
+use self::cpuidle::CpuIdle;
 use self::disk::Disk;
 use self::ebpf::Ebpf;
 use self::general::General;
@@ -39,6 +41,8 @@ pub struct Config {
     container: Container,
     #[serde(default)]
     cpu: Cpu,
+    #[serde(default)]
+    cpuidle: CpuIdle,
     #[serde(default)]
     disk: Disk,
     #[serde(default)]
@@ -125,6 +129,10 @@ impl Config {
 
     pub fn cpu(&self) -> &Cpu {
         &self.cpu
+    }
+
+    pub fn cpuidle(&self) -> &CpuIdle {
+        &self.cpuidle
     }
 
     pub fn disk(&self) -> &Disk {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,10 @@ fn main() {
             let token = samplers.insert((s, Stats::default()));
             timer.add(token, config.interval());
         }
+        if let Ok(Some(s)) = samplers::CpuIdle::new(&config, &metrics) {
+            let token = samplers.insert((s, Stats::default()));
+            timer.add(token, config.interval());
+        }
         if let Ok(Some(s)) = samplers::Disk::new(&config, &metrics) {
             let token = samplers.insert((s, Stats::default()));
             timer.add(token, config.interval());

--- a/src/samplers/cpuidle/mod.rs
+++ b/src/samplers/cpuidle/mod.rs
@@ -1,0 +1,90 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub(crate) mod statistics;
+
+use self::statistics::*;
+use crate::common::file::file_as_u64;
+use crate::config::*;
+use crate::samplers::{Common, Sampler};
+
+use failure::Error;
+use logger::*;
+use metrics::*;
+use time;
+
+pub struct CpuIdle<'a> {
+    common: Common<'a>,
+    cores: u64,
+}
+
+// Get CPU idle usage for a given state and CPU, in nanoseconds.
+fn get_cpuidle_usage(cpu: u64, state: &Statistic) -> Result<u64, ()> {
+    let filename = format!("/sys/devices/system/cpu/cpu{}/{}/usage", cpu, state);
+    file_as_u64(filename).map(|x| x * 1000)
+}
+
+impl<'a> Sampler<'a> for CpuIdle<'a> {
+    fn new(
+        config: &'a Config,
+        metrics: &'a Metrics<AtomicU32>,
+    ) -> Result<Option<Box<Self>>, Error> {
+        if config.cpuidle().enabled() {
+            Ok(Some(Box::new(CpuIdle {
+                common: Common::new(config, metrics),
+                cores: crate::common::hardware_threads().unwrap_or(1),
+            })))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn common(&self) -> &Common<'a> {
+        &self.common
+    }
+
+    fn name(&self) -> String {
+        "cpuidle".to_string()
+    }
+
+    fn sample(&mut self) -> Result<(), ()> {
+        trace!("sample {}", self.name());
+        let time = time::precise_time_ns();
+        self.register();
+        for statistic in self.common.config().cpuidle().statistics() {
+            let mut sum: u64 = 0;
+            for core in 0..self.cores {
+                sum += get_cpuidle_usage(core, &statistic)?;
+            }
+            self.common.record_counter(&statistic, time, sum);
+        }
+        Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .cpuidle()
+            .interval()
+            .unwrap_or_else(|| self.common().config().interval())
+    }
+
+    fn register(&mut self) {
+        trace!("register {}", self.name());
+        if !self.common.initialized() {
+            for statistic in self.common.config().cpuidle().statistics() {
+                self.common.register_counter(&statistic, 0, 0, &[]);
+            }
+            self.common.set_initialized(true);
+        }
+    }
+
+    fn deregister(&mut self) {
+        trace!("deregister {}", self.name());
+        for statistic in self.common.config().cpu().statistics() {
+            self.common.delete_channel(&statistic);
+        }
+        self.common.set_initialized(false);
+    }
+}

--- a/src/samplers/cpuidle/statistics.rs
+++ b/src/samplers/cpuidle/statistics.rs
@@ -1,0 +1,25 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use serde_derive::*;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum Statistic {
+    State0,
+    State1,
+    State2,
+    State3,
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::State0 => write!(f, "cpuidle/state0"),
+            Self::State1 => write!(f, "cpuidle/state1"),
+            Self::State2 => write!(f, "cpuidle/state2"),
+            Self::State3 => write!(f, "cpuidle/state3"),
+        }
+    }
+}

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod container;
 pub(crate) mod cpu;
+pub(crate) mod cpuidle;
 pub(crate) mod disk;
 #[cfg(feature = "ebpf")]
 pub(crate) mod ebpf;
@@ -16,6 +17,7 @@ pub(crate) mod softnet;
 
 pub use self::container::Container;
 pub use self::cpu::Cpu;
+pub use self::cpuidle::CpuIdle;
 pub use self::disk::Disk;
 pub use self::memcache::Memcache;
 pub use self::network::Network;


### PR DESCRIPTION
This reports the total amount of time spent in each cpuidle state across
all cores.

A few things aren't great about this:

* The filename to read the cpuidle usage out of is derived from the metric name - the metric name cannot be changed without breaking the code
* There aren't any tests - I can't see a great way to test this without mocking out the filesystem

Happy to have feedback on either of these. I also wasn't sure whether to put this in the cpu sampler or to make a new sampler - thoughts on that?