### PR TITLE
simplify `Sampler` trait

### DIFF
--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -22,16 +22,17 @@ use time;
 use walkdir::WalkDir;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 const REFRESH: u64 = 60_000_000_000;
 
-pub struct Disk<'a> {
-    common: Common<'a>,
+pub struct Disk {
+    common: Common,
     devices: Vec<Device>,
     last_refreshed: u64,
 }
 
-impl<'a> Disk<'a> {
+impl Disk {
     /// send deltas to the stats library
     fn record(&self, time: u64, reading: Entry) {
         self.common
@@ -64,23 +65,23 @@ impl<'a> Disk<'a> {
     }
 }
 
-impl<'a> Sampler<'a> for Disk<'a> {
+impl Sampler for Disk {
     fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         if config.disk().enabled() {
             Ok(Some(Box::new(Self {
                 common: Common::new(config, metrics),
                 devices: Vec::new(),
                 last_refreshed: 0,
-            })))
+            }) as Box<dyn Sampler>))
         } else {
             Ok(None)
         }
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -60,7 +60,10 @@ impl Block {
 }
 
 impl Sampler for Block {
-    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c");

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -17,16 +17,15 @@ use logger::*;
 use metrics::*;
 use time;
 
-pub struct Ext4<'a> {
+use std::sync::Arc;
+
+pub struct Ext4 {
     bpf: BPF,
-    common: Common<'a>,
+    common: Common,
 }
 
-impl<'a> Sampler<'a> for Ext4<'a> {
-    fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+impl Sampler for Ext4 {
+    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();
@@ -57,10 +56,10 @@ impl<'a> Sampler<'a> for Ext4<'a> {
         Ok(Some(Box::new(Self {
             bpf,
             common: Common::new(config, metrics),
-        })))
+        }) as Box<dyn Sampler>))
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -25,7 +25,10 @@ pub struct Ext4 {
 }
 
 impl Sampler for Ext4 {
-    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -17,16 +17,15 @@ use logger::*;
 use metrics::*;
 use time;
 
-pub struct Scheduler<'a> {
+use std::sync::Arc;
+
+pub struct Scheduler {
     bpf: BPF,
-    common: Common<'a>,
+    common: Common,
 }
 
-impl<'a> Sampler<'a> for Scheduler<'a> {
-    fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+impl Sampler for Scheduler {
+    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c");
@@ -44,10 +43,10 @@ impl<'a> Sampler<'a> for Scheduler<'a> {
         Ok(Some(Box::new(Self {
             bpf,
             common: Common::new(config, metrics),
-        })))
+        }) as Box<dyn Sampler>))
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -25,7 +25,10 @@ pub struct Scheduler {
 }
 
 impl Sampler for Scheduler {
-    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c");

--- a/src/samplers/ebpf/tcp/mod.rs
+++ b/src/samplers/ebpf/tcp/mod.rs
@@ -17,16 +17,15 @@ use logger::*;
 use metrics::*;
 use time;
 
-pub struct Tcp<'a> {
+use std::sync::Arc;
+
+pub struct Tcp {
     bpf: BPF,
-    common: Common<'a>,
+    common: Common,
 }
 
-impl<'a> Sampler<'a> for Tcp<'a> {
-    fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+impl Sampler for Tcp {
+    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();
@@ -44,10 +43,10 @@ impl<'a> Sampler<'a> for Tcp<'a> {
         Ok(Some(Box::new(Self {
             bpf,
             common: Common::new(config, metrics),
-        })))
+        }) as Box<dyn Sampler>))
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/ebpf/tcp/mod.rs
+++ b/src/samplers/ebpf/tcp/mod.rs
@@ -25,7 +25,10 @@ pub struct Tcp {
 }
 
 impl Sampler for Tcp {
-    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -25,7 +25,10 @@ pub struct Xfs {
 }
 
 impl Sampler for Xfs {
-    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -17,16 +17,15 @@ use logger::*;
 use metrics::*;
 use time;
 
-pub struct Xfs<'a> {
+use std::sync::Arc;
+
+pub struct Xfs {
     bpf: BPF,
-    common: Common<'a>,
+    common: Common,
 }
 
-impl<'a> Sampler<'a> for Xfs<'a> {
-    fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+impl Sampler for Xfs {
+    fn new(config: Arc<Config>, metrics: Metrics<AtomicU32>) -> Result<Option<Box<Self>>, Error> {
         debug!("initializing");
         // load the code and compile
         let code = include_str!("bpf.c").to_string();
@@ -54,10 +53,10 @@ impl<'a> Sampler<'a> for Xfs<'a> {
         Ok(Some(Box::new(Self {
             bpf,
             common: Common::new(config, metrics),
-        })))
+        }) as Box<dyn Sampler>))
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/perf/mod.rs
+++ b/src/samplers/perf/mod.rs
@@ -16,17 +16,18 @@ use perfcnt::{AbstractPerfCounter, PerfCounter};
 use time;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
-pub struct Perf<'a> {
-    common: Common<'a>,
+pub struct Perf {
+    common: Common,
     counters: HashMap<Statistic, Vec<PerfCounter>>,
 }
 
-impl<'a> Sampler<'a> for Perf<'a> {
+impl Sampler for Perf {
     fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         if config.perf().enabled() {
             let mut counters = HashMap::new();
             let cores = hardware_threads().unwrap_or(1);
@@ -56,13 +57,13 @@ impl<'a> Sampler<'a> for Perf<'a> {
             Ok(Some(Box::new(Self {
                 common: Common::new(config, metrics),
                 counters,
-            })))
+            }) as Box<dyn Sampler>))
         } else {
             Ok(None)
         }
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -16,9 +16,10 @@ use time;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
-pub struct Rezolus<'a> {
-    common: Common<'a>,
+pub struct Rezolus {
+    common: Common,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -90,7 +91,7 @@ fn parse_process_stats<P: AsRef<Path>>(path: P) -> HashMap<ProcessStat, u64> {
     result
 }
 
-impl<'a> Rezolus<'a> {
+impl Rezolus {
     pub fn gauges(&self) -> Vec<String> {
         vec![
             Statistic::MemoryResident.to_string(),
@@ -140,17 +141,17 @@ impl<'a> Rezolus<'a> {
     }
 }
 
-impl<'a> Sampler<'a> for Rezolus<'a> {
+impl Sampler for Rezolus {
     fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         Ok(Some(Box::new(Rezolus {
             common: Common::new(config, metrics),
-        })))
+        }) as Box<dyn Sampler>))
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -18,11 +18,12 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use std::sync::Arc;
 
 const SOFTNET_STAT: &str = "/proc/net/softnet_stat";
 
-pub struct Softnet<'a> {
-    common: Common<'a>,
+pub struct Softnet {
+    common: Common,
 }
 
 pub fn read_softnet_stat<P: AsRef<Path>>(path: P) -> HashMap<Statistic, u64> {
@@ -57,21 +58,21 @@ pub fn read_softnet_stat<P: AsRef<Path>>(path: P) -> HashMap<Statistic, u64> {
     result
 }
 
-impl<'a> Sampler<'a> for Softnet<'a> {
+impl Sampler for Softnet {
     fn new(
-        config: &'a Config,
-        metrics: &'a Metrics<AtomicU32>,
-    ) -> Result<Option<Box<Self>>, Error> {
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
         if config.softnet().enabled() {
             Ok(Some(Box::new(Self {
                 common: Common::new(config, metrics),
-            })))
+            }) as Box<dyn Sampler>))
         } else {
             Ok(None)
         }
     }
 
-    fn common(&self) -> &Common<'a> {
+    fn common(&self) -> &Common {
         &self.common
     }
 


### PR DESCRIPTION
Simplifies the `Sampler` trait in terms of both the constructor and
its return type. Previously, lifetime annotations were required and
lead to some issues completing a similar refactor. By switching to
owned structures for configuration and metrics, we are able to
remove the need for lifetime annotations and change the return type
to a dynamic type instead of a concrete type. This allows us to
reduce the boilerplate in main for sampler initialization
