### PR TITLE
make sampler initialization errors fatal in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - cargo build --release --verbose
         - cargo test --release --verbose
         - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/ci.toml
     - os: linux
       rust: nightly
       env: TYPE=ebpf RUST_BACKTRACE=1
@@ -41,6 +42,7 @@ matrix:
         - cargo test --release --features ebpf
         - cargo run --release --features ebpf -- --version
         - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/ci.toml
     - os: linux
       rust: stable
       env: TYPE=rustfmt RUST_BACKTRACE=1

--- a/configs/ci.toml
+++ b/configs/ci.toml
@@ -1,0 +1,33 @@
+# This config is used to validate Rezolus in CI environments. The main
+# difference between it and the example is that faults in sampler initialization
+# will result in errors as opposed to being silently handled
+
+# settings that apply to the entire process
+[general]
+listen = "0.0.0.0:4242"
+fault_tolerant = false
+
+[cpu]
+enabled = true
+
+[cpuidle]
+enabled = true
+
+[disk]
+enabled = true
+
+[ebpf]
+block = true
+ext4 = true
+scheduler = true
+tcp = true
+xfs = false
+
+[network]
+enabled = true
+
+[perf]
+enabled = true
+
+[softnet]
+enabled = true

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -23,6 +23,8 @@ pub struct General {
     #[serde(default = "default_max_timeouts")]
     max_timeouts: AtomicUsize,
     stats_log: Option<String>,
+    #[serde(default = "default_fault_tolerant")]
+    fault_tolerant: AtomicBool,
 }
 
 impl General {
@@ -61,6 +63,10 @@ impl General {
     pub fn stats_log(&self) -> Option<String> {
         self.stats_log.clone()
     }
+
+    pub fn fault_tolerant(&self) -> bool {
+        self.fault_tolerant.load(Ordering::Relaxed)
+    }
 }
 
 impl Default for General {
@@ -74,6 +80,7 @@ impl Default for General {
             max_timeouts: default_max_timeouts(),
             stats_log: None,
             memcache: None,
+            fault_tolerant: default_fault_tolerant(),
         }
     }
 }
@@ -92,6 +99,10 @@ fn default_timeout() -> AtomicUsize {
 
 fn default_max_timeouts() -> AtomicUsize {
     AtomicUsize::new(5)
+}
+
+fn default_fault_tolerant() -> AtomicBool {
+    AtomicBool::new(true)
 }
 
 #[derive(Clone, Deserialize, Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -164,6 +164,10 @@ impl Config {
         &self.ebpf
     }
 
+    pub fn fault_tolerant(&self) -> bool {
+        self.general().fault_tolerant()
+    }
+
     fn load_from_file(filename: &str) -> Config {
         let mut file = std::fs::File::open(filename).expect("failed to open workload file");
         let mut content = String::new();


### PR DESCRIPTION
Problem

Previously, errors during sampler initialization are always handled in a
fault tolerant manner. This is great for actual runtime stability; however,
it can cause tests to pass in CI even for errors we do care about.

Solution

Adds a new configuration option, so we can disable the normal fault
tolerant behavior. Changes the sampler initialization to have logic to
cause a fatal error if initialization returns an error and we have fault
tolerance disabled. Fixes an issue where all eBPF samplers are initialized
if any are enabled. Disabled eBPF XFS sampler in CI due to some issue
with the kprobes and the CI environment. 

Result

CI smoke test will fail if there are issues with sampler initialization.

Fixes #60