### PR TITLE
add network packet size distribution via eBPF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Added
 - Configuration flag to disable fault tolerance, enabling proper smoke tests of
   sampler initialization in CI
+- Network eBPF sampler which provides packet size distribution
 
 ## Fixed
 - Fixes build issue when `perf` feature is disabled

--- a/configs/ci-no_perf.toml
+++ b/configs/ci-no_perf.toml
@@ -19,6 +19,7 @@ enabled = true
 [ebpf]
 block = true
 ext4 = true
+network = true
 scheduler = true
 tcp = true
 xfs = false

--- a/configs/ci.toml
+++ b/configs/ci.toml
@@ -19,6 +19,7 @@ enabled = true
 [ebpf]
 block = true
 ext4 = true
+network = true
 scheduler = true
 tcp = true
 xfs = false

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -54,8 +54,14 @@ block = true
 # enable or disable collection for ext4
 ext4 = true
 
+# enable or disable collection for network
+network = true
+
 # enable or disable collection for scheduler
 scheduler = true
+
+# enable or disable collection for tcp
+tcp = true
 
 # enable or disable collection for xfs
 xfs = true

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -98,12 +98,26 @@ Capture system-wide filesystem latency for EXT4
 * `ext4/fsync` - distribution of latency for fsync operations in nanoseconds
 * `ext4/open` - distribution of latency for open operations in nanoseconds
 
+### Network
+
+Provides additional system-wide telemetry for networking
+
+* `network/receive/size` - distribution of received packet sizes in bytes
+* `network/transmit/size` - distribution of transmitted packet sizes in bytes
+
 ### Scheduler
 
 Captures system-wide scheduler telemetry
 
 * `scheduler/runqueue_latency_ns` - distribution of the amount of time in
   nanoseconds that runnable tasks are waiting to be scheduled onto a core
+
+### TCP
+
+Captures additional system-wide telemetry for TCP
+
+* `network/tcp/connect/latency` - distribution of latency for establishing
+active (outbound) connections
 
 ### XFS
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -22,14 +22,23 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const NAME: &str = env!("CARGO_PKG_NAME");
 
 // units
+pub const ONE: u64 = 1;
 pub const THOUSAND: u64 = 1_000;
 pub const MILLION: u64 = 1_000_000;
 pub const BILLION: u64 = 1_000_000_000;
 pub const TRILLION: u64 = 1_000_000_000_000;
+
+// time units
+pub const NANOSECOND: u64 = ONE;
 pub const MICROSECOND: u64 = THOUSAND; // 1US in NS
 pub const MILLISECOND: u64 = MILLION; // 1MS in NS
 pub const SECOND: u64 = BILLION; // 1S in NS
 pub const MINUTE: u64 = 60 * SECOND;
+
+// size units
+pub const BYTE: u64 = ONE;
+pub const KILOBYTE: u64 = THOUSAND;
+pub const MEGABYTE: u64 = MILLION;
 pub const GIGABYTE: u64 = BILLION;
 pub const TERABYTE: u64 = TRILLION;
 
@@ -48,7 +57,6 @@ pub const CONTAINER_REFRESH: u64 = MINUTE;
 pub const HTTP_TIMEOUT: u64 = 500 * MILLISECOND;
 pub const POLL_DELAY: u64 = 50 * MILLISECOND;
 pub const SECTOR_SIZE: u64 = 512; //bytes per sector
-pub const UNITY: u64 = 1;
 
 // reported percentiles
 pub const PERCENTILES: &[Percentile] = &[

--- a/src/config/ebpf.rs
+++ b/src/config/ebpf.rs
@@ -18,6 +18,8 @@ pub struct Ebpf {
     #[serde(default = "default_interval")]
     interval: AtomicOption<AtomicUsize>,
     #[serde(default = "default")]
+    network: AtomicBool,
+    #[serde(default = "default")]
     scheduler: AtomicBool,
     #[serde(default = "default")]
     tcp: AtomicBool,
@@ -32,6 +34,7 @@ impl Default for Ebpf {
             block: default(),
             ext4: default(),
             interval: default_interval(),
+            network: default(),
             scheduler: default(),
             tcp: default(),
             xfs: default(),
@@ -66,6 +69,11 @@ impl Ebpf {
     #[allow(dead_code)]
     pub fn ext4(&self) -> bool {
         self.all.load(Ordering::Relaxed) || self.ext4.load(Ordering::Relaxed)
+    }
+
+    #[allow(dead_code)]
+    pub fn network(&self) -> bool {
+        self.all.load(Ordering::Relaxed) || self.network.load(Ordering::Relaxed)
     }
 
     #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ fn main() {
             for sampler in vec![
                 ebpf::Block::new(config.clone(), metrics.clone()),
                 ebpf::Ext4::new(config.clone(), metrics.clone()),
+                ebpf::Network::new(config.clone(), metrics.clone()),
                 ebpf::Scheduler::new(config.clone(), metrics.clone()),
                 ebpf::Tcp::new(config.clone(), metrics.clone()),
                 ebpf::Xfs::new(config.clone(), metrics.clone()),

--- a/src/samplers/ebpf/block/mod.rs
+++ b/src/samplers/ebpf/block/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::{Direction, Statistic};
 use super::map_from_table;
-use crate::common::{BILLION, MICROSECOND, MILLION, PERCENTILES, UNITY};
+use crate::common::*;
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 
@@ -53,7 +53,7 @@ impl Block {
 
         self.register();
 
-        for (&value, &count) in &map_from_table(&mut table, UNITY) {
+        for (&value, &count) in &map_from_table(&mut table, BYTE) {
             self.common.record_distribution(&label, time, value, count);
         }
     }
@@ -131,11 +131,7 @@ impl Sampler for Block {
                 Statistic::Size(Direction::Write),
             ] {
                 self.common
-                    .register_distribution(statistic, MILLION, 2, PERCENTILES);
-            }
-            for size in &["block/size/read", "block/size/write"] {
-                self.common
-                    .register_distribution(size, MILLION, 2, PERCENTILES);
+                    .register_distribution(statistic, MEGABYTE, 2, PERCENTILES);
             }
             for statistic in &[
                 Statistic::Latency(Direction::Read),
@@ -146,7 +142,7 @@ impl Sampler for Block {
                 Statistic::QueueLatency(Direction::Write),
             ] {
                 self.common
-                    .register_distribution(statistic, BILLION, 2, PERCENTILES);
+                    .register_distribution(statistic, SECOND, 2, PERCENTILES);
             }
             self.common.set_initialized(true);
         }

--- a/src/samplers/ebpf/ext4/mod.rs
+++ b/src/samplers/ebpf/ext4/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use super::map_from_table;
-use crate::common::{MICROSECOND, PERCENTILES, SECOND};
+use crate::common::*;
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 

--- a/src/samplers/ebpf/mod.rs
+++ b/src/samplers/ebpf/mod.rs
@@ -4,12 +4,14 @@
 
 mod block;
 mod ext4;
+mod network;
 mod scheduler;
 mod tcp;
 mod xfs;
 
 pub use self::block::Block;
 pub use self::ext4::Ext4;
+pub use self::network::Network;
 pub use self::scheduler::Scheduler;
 pub use self::tcp::Tcp;
 pub use self::xfs::Xfs;

--- a/src/samplers/ebpf/network/bpf.c
+++ b/src/samplers/ebpf/network/bpf.c
@@ -1,0 +1,53 @@
+
+#include <uapi/linux/ptrace.h>
+
+BPF_HISTOGRAM(rx_size, int, 461);
+BPF_HISTOGRAM(tx_size, int, 461);
+
+// histogram indexing
+static unsigned int value_to_index2(unsigned int value) {
+    unsigned int index = 460;
+    if (value < 100) {
+        // 0-99 => [0..100)
+        // 0 => 0
+        // 99 => 99
+        index = value;
+    } else if (value < 1000) {
+        // 100-999 => [100..190)
+        // 100 => 100
+        // 999 => 189
+        index = 90 + value / 10;
+    } else if (value < 10000) {
+        // 1_000-9_999 => [190..280)
+        // 1000 => 190
+        // 9999 => 279
+        index = 180 + value / 100;
+    } else if (value < 100000) {
+        // 10_000-99_999 => [280..370)
+        // 10000 => 280
+        // 99999 => 369
+        index = 270 + value / 1000;
+    } else if (value < 1000000) {
+        // 100_000-999_999 => [370..460)
+        // 100000 => 370
+        // 999999 => 459
+        index = 360 + value / 10000;
+    } else {
+        index = 460;
+    }
+    return index;
+}
+
+int trace_transmit(struct tracepoint__net__net_dev_queue *args)
+{
+    u64 index = value_to_index2(args->len);
+    tx_size.increment(index);
+    return 0;
+}
+
+int trace_receive(struct tracepoint__net__netif_rx *args)
+{
+    u64 index = value_to_index2(args->len);
+    rx_size.increment(index);
+    return 0;
+}

--- a/src/samplers/ebpf/network/bpf.c
+++ b/src/samplers/ebpf/network/bpf.c
@@ -1,3 +1,6 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 
 #include <uapi/linux/ptrace.h>
 

--- a/src/samplers/ebpf/network/mod.rs
+++ b/src/samplers/ebpf/network/mod.rs
@@ -1,0 +1,104 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod statistics;
+
+use self::statistics::Statistic;
+use super::map_from_table;
+use crate::common::*;
+use crate::config::*;
+use crate::samplers::{Common, Sampler};
+
+use bcc;
+use bcc::core::BPF;
+use failure::*;
+use logger::*;
+use metrics::*;
+use time;
+
+use std::sync::Arc;
+
+pub struct Network {
+    bpf: BPF,
+    common: Common,
+}
+
+impl Sampler for Network {
+    fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+    ) -> Result<Option<Box<dyn Sampler>>, Error> {
+        if config.ebpf().network() {
+            debug!("initializing");
+            // load the code and compile
+            let code = include_str!("bpf.c").to_string();
+            let mut bpf = BPF::new(&code)?;
+
+            // load + attach kprobes!
+            let trace_transmit = bpf.load_tracepoint("trace_transmit")?;
+            bpf.attach_tracepoint("net", "net_dev_queue", trace_transmit)?;
+
+            let trace_receive = bpf.load_tracepoint("trace_receive")?;
+            bpf.attach_tracepoint("net", "netif_rx", trace_receive)?;
+
+            Ok(Some(Box::new(Self {
+                bpf,
+                common: Common::new(config, metrics),
+            }) as Box<dyn Sampler>))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn common(&self) -> &Common {
+        &self.common
+    }
+
+    fn name(&self) -> String {
+        "ebpf::network".to_string()
+    }
+
+    fn sample(&mut self) -> Result<(), ()> {
+        // gather current state
+        trace!("sampling {}", self.name());
+        let time = time::precise_time_ns();
+        self.register();
+        for statistic in &[Statistic::ReceiveSize, Statistic::TransmitSize] {
+            trace!("sampling {}", statistic);
+            let mut table = self.bpf.table(&statistic.table_name());
+            for (&value, &count) in &map_from_table(&mut table, BYTE) {
+                self.common
+                    .record_distribution(statistic, time, value, count);
+            }
+        }
+        Ok(())
+    }
+
+    fn interval(&self) -> usize {
+        self.common()
+            .config()
+            .ebpf()
+            .interval()
+            .unwrap_or_else(|| self.common().config().interval())
+    }
+
+    fn register(&mut self) {
+        if !self.common.initialized() {
+            trace!("register {}", self.name());
+            for statistic in &[Statistic::ReceiveSize, Statistic::TransmitSize] {
+                self.common
+                    .register_distribution(statistic, MEGABYTE, 2, PERCENTILES);
+            }
+            self.common.set_initialized(true);
+        }
+    }
+
+    fn deregister(&mut self) {
+        trace!("deregister {}", self.name());
+        for statistic in &[Statistic::ReceiveSize, Statistic::TransmitSize] {
+            self.common.delete_channel(statistic);
+        }
+        self.common.set_initialized(false);
+    }
+}

--- a/src/samplers/ebpf/network/statistics.rs
+++ b/src/samplers/ebpf/network/statistics.rs
@@ -1,0 +1,26 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub enum Statistic {
+    ReceiveSize,
+    TransmitSize,
+}
+
+impl std::fmt::Display for Statistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::ReceiveSize => write!(f, "network/receive/size"),
+            Self::TransmitSize => write!(f, "network/transmit/size"),
+        }
+    }
+}
+
+impl Statistic {
+    pub fn table_name(&self) -> String {
+        match self {
+            Self::ReceiveSize => "rx_size".to_string(),
+            Self::TransmitSize => "tx_size".to_string(),
+        }
+    }
+}

--- a/src/samplers/ebpf/scheduler/mod.rs
+++ b/src/samplers/ebpf/scheduler/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use super::map_from_table;
-use crate::common::{MICROSECOND, PERCENTILES, SECOND};
+use crate::common::*;
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 

--- a/src/samplers/ebpf/tcp/mod.rs
+++ b/src/samplers/ebpf/tcp/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use super::map_from_table;
-use crate::common::{MICROSECOND, PERCENTILES, SECOND};
+use crate::common::*;
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 

--- a/src/samplers/ebpf/xfs/mod.rs
+++ b/src/samplers/ebpf/xfs/mod.rs
@@ -6,7 +6,7 @@ mod statistics;
 
 use self::statistics::Statistic;
 use super::map_from_table;
-use crate::common::{MICROSECOND, PERCENTILES, SECOND};
+use crate::common::*;
 use crate::config::*;
 use crate::samplers::{Common, Sampler};
 


### PR DESCRIPTION
Problem

We'd like to get insight into the distribution of packet sizes

Solution

Adds an eBPF sampler which uses tracepoints to get the lengths for
receive and transmit

