### PR TITLE
adds support for nvme block devices

### DIFF
--- a/src/samplers/disk/entry.rs
+++ b/src/samplers/disk/entry.rs
@@ -13,15 +13,25 @@ pub struct Entry {
     read_ops: u64,
     write_bytes: u64,
     write_ops: u64,
+    discard_bytes: u64,
+    discard_ops: u64,
 }
 
 impl Entry {
+    pub fn discard_bytes(&self) -> u64 {
+        self.discard_bytes
+    }
+
     pub fn read_bytes(&self) -> u64 {
         self.read_bytes
     }
 
     pub fn write_bytes(&self) -> u64 {
         self.write_bytes
+    }
+
+    pub fn discard_ops(&self) -> u64 {
+        self.discard_ops
     }
 
     pub fn read_ops(&self) -> u64 {
@@ -37,7 +47,7 @@ impl Entry {
             file::string_from_file(format!("/sys/class/block/{}/stat", device.name().unwrap()))
         {
             let parts: Vec<&str> = content.split_whitespace().collect();
-            if parts.len() != 11 {
+            if parts.len() < 11 {
                 debug!(
                     "Unable to parse stats for block device: {}",
                     device.name().unwrap_or_else(|| "Total".to_owned())
@@ -48,6 +58,8 @@ impl Entry {
                 read_bytes: parts[2].parse().unwrap_or(0) * SECTOR_SIZE,
                 write_ops: parts[4].parse().unwrap_or(0),
                 write_bytes: parts[6].parse().unwrap_or(0) * SECTOR_SIZE,
+                discard_ops: parts.get(11).unwrap_or(&"0").parse().unwrap_or(0),
+                discard_bytes: parts.get(13).unwrap_or(&"0").parse().unwrap_or(0) * SECTOR_SIZE,
             }
         } else {
             Entry::default()
@@ -62,6 +74,8 @@ impl Default for Entry {
             read_ops: 0,
             write_bytes: 0,
             write_ops: 0,
+            discard_bytes: 0,
+            discard_ops: 0,
         }
     }
 }
@@ -75,6 +89,8 @@ impl Add for Entry {
             read_ops: self.read_ops.wrapping_add(rhs.read_ops),
             write_bytes: self.write_bytes.wrapping_add(rhs.write_bytes),
             write_ops: self.write_ops.wrapping_add(rhs.write_ops),
+            discard_bytes: self.discard_bytes.wrapping_add(rhs.discard_bytes),
+            discard_ops: self.discard_ops.wrapping_add(rhs.discard_ops),
         }
     }
 }
@@ -94,6 +110,8 @@ impl<'a> Add<&'a Entry> for Entry {
             read_ops: self.read_ops.wrapping_add(rhs.read_ops),
             write_bytes: self.write_bytes.wrapping_add(rhs.write_bytes),
             write_ops: self.write_ops.wrapping_add(rhs.write_ops),
+            discard_bytes: self.discard_bytes.wrapping_add(rhs.discard_bytes),
+            discard_ops: self.discard_ops.wrapping_add(rhs.discard_ops),
         }
     }
 }
@@ -107,6 +125,8 @@ impl<'a, 'b> Add<&'b Entry> for &'a Entry {
             read_ops: self.read_ops.wrapping_add(rhs.read_ops),
             write_bytes: self.write_bytes.wrapping_add(rhs.write_bytes),
             write_ops: self.write_ops.wrapping_add(rhs.write_ops),
+            discard_bytes: self.discard_bytes.wrapping_add(rhs.discard_bytes),
+            discard_ops: self.discard_ops.wrapping_add(rhs.discard_ops),
         }
     }
 }
@@ -120,6 +140,8 @@ impl Sub for Entry {
             read_ops: self.read_ops.wrapping_sub(rhs.read_ops),
             write_bytes: self.write_bytes.wrapping_sub(rhs.write_bytes),
             write_ops: self.write_ops.wrapping_sub(rhs.write_ops),
+            discard_bytes: self.discard_bytes.wrapping_sub(rhs.discard_bytes),
+            discard_ops: self.discard_ops.wrapping_sub(rhs.discard_ops),
         }
     }
 }

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -124,11 +124,19 @@ impl Sampler for Disk {
             trace!("register {}", self.name());
             self.devices = self.get_devices();
             self.last_refreshed = time::precise_time_ns();
-            for statistic in &[Statistic::BandwidthDiscard, Statistic::BandwidthRead, Statistic::BandwidthWrite] {
+            for statistic in &[
+                Statistic::BandwidthDiscard,
+                Statistic::BandwidthRead,
+                Statistic::BandwidthWrite,
+            ] {
                 self.common
                     .register_counter(statistic, TRILLION, 3, PERCENTILES);
             }
-            for statistic in &[Statistic::OperationsDiscard, Statistic::OperationsRead, Statistic::OperationsWrite] {
+            for statistic in &[
+                Statistic::OperationsDiscard,
+                Statistic::OperationsRead,
+                Statistic::OperationsWrite,
+            ] {
                 self.common
                     .register_counter(statistic, BILLION, 3, PERCENTILES);
             }

--- a/src/samplers/disk/statistics.rs
+++ b/src/samplers/disk/statistics.rs
@@ -7,8 +7,10 @@ use serde_derive::*;
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum Statistic {
+    BandwidthDiscard,
     BandwidthRead,
     BandwidthWrite,
+    OperationsDiscard,
     OperationsRead,
     OperationsWrite,
 }
@@ -16,8 +18,10 @@ pub enum Statistic {
 impl std::fmt::Display for Statistic {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            Statistic::BandwidthDiscard => write!(f, "disk/bandwidth/discard"),
             Statistic::BandwidthRead => write!(f, "disk/bandwidth/read"),
             Statistic::BandwidthWrite => write!(f, "disk/bandwidth/write"),
+            Statistic::OperationsDiscard => write!(f, "disk/operations/discard"),
             Statistic::OperationsRead => write!(f, "disk/operations/read"),
             Statistic::OperationsWrite => write!(f, "disk/operations/write"),
         }


### PR DESCRIPTION
Problem

nvme block devices are skipped under the current disk sampler

Solution

Extends the current disk sampler's matching to include nvme block
devices. Adds support for reporting discard ops / bandwidth

Result

Telemetry for nvme block devices is exported. Additional telemetry
for SSDs
