### PR TITLE
Add support for pushing metrics to Kafka

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -297,6 +297,18 @@ matrix:
         - cargo run --release --features ebpf -- --version
         - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
         - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/ci.toml
+    - name: "push_kafka: xenial / nightly"
+      os: linux
+      dist: xenial
+      rust: nightly
+      env: RUST_BACKTRACE=1
+      script:
+        - cargo build --features push_kafka --verbose
+        - cargo test --features push_kafka --verbose
+        - cargo build --release --features push_kafka --verbose
+        - cargo test --release --features push_kafka --verbose
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/example.toml
+        - sudo timeout --preserve-status 5.0m target/release/rezolus --config configs/ci.toml
     - name: "no-default: xenial / stable"
       os: linux
       dist: xenial

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +157,14 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,6 +227,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "evmap"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +261,33 @@ dependencies = [
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "flate2"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -267,6 +320,23 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kafka"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ref_slice 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +366,14 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -337,6 +415,15 @@ dependencies = [
  "evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -384,6 +471,31 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,6 +574,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -611,6 +728,11 @@ version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ref_slice"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +774,7 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kafka 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/twitter/rpc-perf)",
  "metrics 0.4.1 (git+https://github.com/twitter/rpc-perf)",
  "perfcnt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -754,6 +877,15 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "snap"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +986,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +1032,11 @@ dependencies = [
 [[package]]
 name = "uuid"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -992,6 +1137,8 @@ dependencies = [
 "checksum bcc-sys 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2b4333fc4e2dd2857af8817416f49b9920724f1860639982c79d8fb4a425518"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
+"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -999,35 +1146,46 @@ dependencies = [
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum datastructures 0.4.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum evmap 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7e08ace17a9241686f923cb5707822823a6e36f36796eb87035d77c158867ab3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3ca41abbeb7615d56322a984e63be5e5d0a117dfaca86c14393e32a762ccac1"
+"checksum kafka 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f37f068eb07305e1141453ea2dccfb4f278153a4261bb9a519f10d1eb13d25a8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum logger 0.1.0 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum metrics 0.4.1 (git+https://github.com/twitter/rpc-perf)" = "<none>"
+"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
 "checksum mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
+"checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
@@ -1036,6 +1194,7 @@ dependencies = [
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+"checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -1052,6 +1211,7 @@ dependencies = [
 "checksum raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30a9d219c32c9132f7be513c18be77c9881c7107d2ab5569d205a6a0f0e6dc7d"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum ref_slice 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e1b7878800220a76a08f32c057829511440f65528b63b940f2f2bc145d7ac68"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
@@ -1069,6 +1229,7 @@ dependencies = [
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
@@ -1080,12 +1241,14 @@ dependencies = [
 "checksum timer 0.1.2 (git+https://github.com/twitter/rpc-perf)" = "<none>"
 "checksum tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
+"checksum twox-hash 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+"checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ clap = "2.33.0"
 ctrlc = "3.1.3"
 failure = "0.1.6"
 json = "0.12.0"
-kafka = "0.8.0"
+kafka = { version = "0.8.0", optional = true }
 logger = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 metrics = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 perfcnt = { version = "0.5.0", optional = true }
@@ -45,6 +45,7 @@ ebpf_v0_9_0 = ["ebpf", "bcc/v0_9_0"]
 ebpf_v0_10_0 = ["ebpf", "bcc/v0_10_0"]
 ebpf_v0_11_0 = ["ebpf", "bcc/v0_11_0"]
 perf = ["perfcnt"]
+push_kafka = ["kafka"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = "2.33.0"
 ctrlc = "3.1.3"
 failure = "0.1.6"
 json = "0.12.0"
+kafka = "0.8.0"
 logger = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 metrics = { git = "https://github.com/twitter/rpc-perf", branch = "master" }
 perfcnt = { version = "0.5.0", optional = true }

--- a/src/config/kafka.rs
+++ b/src/config/kafka.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::config::*;
+
+use atomics::*;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Kafka {
+    #[serde(default = "default_enabled")]
+    enabled: AtomicBool,
+    #[serde(default = "default_interval")]
+    interval: AtomicUsize,
+    hosts: Vec<String>,
+    topic: Option<String>,
+}
+
+impl Default for Kafka {
+    fn default() -> Kafka {
+        Kafka {
+            enabled: default_enabled(),
+            interval: default_interval(),
+            hosts: vec![],
+            topic: None,
+        }
+    }
+}
+
+fn default_enabled() -> AtomicBool {
+    AtomicBool::new(false)
+}
+
+fn default_interval() -> AtomicUsize {
+    AtomicUsize::new(500)
+}
+
+impl Kafka {
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn interval(&self) -> usize {
+        self.interval.load(Ordering::Relaxed)
+    }
+
+    pub fn hosts(&self) -> Vec<String> {
+        self.hosts.clone()
+    }
+
+    pub fn topic(&self) -> Option<String> {
+        self.topic.clone()
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,6 +8,7 @@ mod cpuidle;
 mod disk;
 mod ebpf;
 mod general;
+mod kafka;
 mod network;
 mod perf;
 mod softnet;
@@ -18,6 +19,7 @@ use self::cpuidle::CpuIdle;
 use self::disk::Disk;
 use self::ebpf::Ebpf;
 use self::general::General;
+use self::kafka::Kafka;
 use self::network::Network;
 use self::perf::Perf;
 use self::softnet::Softnet;
@@ -49,6 +51,8 @@ pub struct Config {
     ebpf: Ebpf,
     #[serde(default)]
     general: General,
+    #[serde(default)]
+    kafka: Kafka,
     #[serde(default)]
     network: Network,
     #[serde(default)]
@@ -145,6 +149,10 @@ impl Config {
 
     pub fn interval(&self) -> usize {
         self.general().interval()
+    }
+
+    pub fn kafka(&self) -> &Kafka {
+        &self.kafka
     }
 
     pub fn network(&self) -> &Network {

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,14 +197,17 @@ fn main() {
             });
     }
 
-    if config.kafka().enabled() {
-        let mut kafka_producer =
-            stats::KafkaProducer::new(config.clone(), metrics.clone(), count_suffix);
-        let _ = thread::Builder::new()
-            .name("kafka".to_string())
-            .spawn(move || loop {
-                kafka_producer.run();
-            });
+    #[cfg(feature = "push_kafka")]
+    {
+        if config.kafka().enabled() {
+            let mut kafka_producer =
+                stats::KafkaProducer::new(config.clone(), metrics.clone(), count_suffix);
+            let _ = thread::Builder::new()
+                .name("kafka".to_string())
+                .spawn(move || loop {
+                    kafka_producer.run();
+                });
+        }
     }
 
     let mut first_run = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,16 @@ fn main() {
             });
     }
 
+    if config.kafka().enabled() {
+        let mut kafka_producer =
+            stats::KafkaProducer::new(config.clone(), metrics.clone(), count_suffix);
+        let _ = thread::Builder::new()
+            .name("kafka".to_string())
+            .spawn(move || loop {
+                kafka_producer.run();
+            });
+    }
+
     let mut first_run = true;
     let mut t0 = time::precise_time_ns();
 

--- a/src/stats/http.rs
+++ b/src/stats/http.rs
@@ -3,6 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::common::MILLISECOND;
+use crate::stats::MetricsSnapshot;
 
 use logger::*;
 use metrics::*;
@@ -11,11 +12,8 @@ use tiny_http::{Method, Response, Server};
 use std::net::SocketAddr;
 
 pub struct Http {
-    metrics: Metrics<AtomicU32>,
+    snapshot: MetricsSnapshot,
     server: Server,
-    snapshot: Vec<Reading>,
-    refreshed: u64,
-    count_label: Option<String>,
 }
 
 impl Http {
@@ -29,19 +27,15 @@ impl Http {
             fatal!("Failed to open {} for HTTP Stats listener", address);
         }
         Self {
-            metrics,
+            snapshot: MetricsSnapshot::new(metrics, count_label),
             server: server.unwrap(),
-            snapshot: Vec::new(),
-            refreshed: 0,
-            count_label: count_label.map(std::string::ToString::to_string),
         }
     }
 
     pub fn run(&mut self) {
         let now = time::precise_time_ns();
-        if now - self.refreshed > 500 * MILLISECOND {
-            self.snapshot = self.metrics.readings();
-            self.refreshed = time::precise_time_ns();
+        if now - self.snapshot.refreshed > 500 * MILLISECOND {
+            self.snapshot.refresh();
         }
         if let Ok(Some(request)) = self.server.try_recv() {
             let url = request.url();
@@ -59,20 +53,20 @@ impl Http {
                     }
                     "/metrics" => {
                         debug!("Serving Prometheus compatible stats");
-                        let _ = request.respond(Response::from_string(self.prometheus()));
+                        let _ = request.respond(Response::from_string(self.snapshot.prometheus()));
                     }
                     "/metrics.json" | "/vars.json" | "/admin/metrics.json" => {
                         debug!("Serving machine readable stats");
-                        let _ = request.respond(Response::from_string(self.json(false)));
+                        let _ = request.respond(Response::from_string(self.snapshot.json(false)));
                     }
                     "/vars" => {
                         debug!("Serving human readable stats");
-                        let _ = request.respond(Response::from_string(self.human()));
+                        let _ = request.respond(Response::from_string(self.snapshot.human()));
                     }
                     url => {
                         debug!("GET on non-existent url: {}", url);
                         debug!("Serving machine readable stats");
-                        let _ = request.respond(Response::from_string(self.json(false)));
+                        let _ = request.respond(Response::from_string(self.snapshot.json(false)));
                     }
                 },
                 method => {
@@ -82,181 +76,5 @@ impl Http {
             }
         }
         std::thread::sleep(std::time::Duration::from_millis(1));
-    }
-
-    pub fn prometheus(&self) -> String {
-        let mut data = Vec::new();
-        for reading in &self.snapshot {
-            let label = reading.label();
-            let output = reading.output();
-            let value = reading.value();
-            match output {
-                Output::Counter => {
-                    if let Some(ref count_label) = self.count_label {
-                        data.push(format!("{}/{} {}", label, count_label, value));
-                    } else {
-                        data.push(format!("{} {}", label, value));
-                    }
-                }
-                Output::Percentile(percentile) => match percentile {
-                    Percentile::Minimum => {
-                        data.push(format!("{}/minimum/value {}", label, value));
-                    }
-                    Percentile::Maximum => {
-                        data.push(format!("{}/maximum/value {}", label, value));
-                    }
-                    _ => {
-                        data.push(format!("{}/histogram/{} {}", label, percentile, value));
-                    }
-                },
-                Output::MaxPointTime => {
-                    // we have point's ns since X and current timespec and current ns sinc X
-                    let point_ns = value;
-                    let now_timespec = time::get_time();
-                    let now_ns = time::precise_time_ns();
-
-                    // find the number of NS in the past for point
-                    let delta_ns = now_ns - point_ns;
-                    let point_timespec =
-                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
-
-                    // convert to UTC
-                    let point_utc = time::at_utc(point_timespec);
-                    // calculate offset from the top of the minute
-                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
-                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
-                    data.push(format!("{}/maximum/offset_ms {}", label, offset_ms));
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-        data.sort();
-        let mut content = data.join("\n");
-        content += "\n";
-        let parts: Vec<&str> = content.split('/').collect();
-        parts.join("_")
-    }
-
-    pub fn human(&self) -> String {
-        let mut data = Vec::new();
-        for reading in &self.snapshot {
-            let label = reading.label();
-            let output = reading.output();
-            let value = reading.value();
-            match output {
-                Output::Counter => {
-                    if let Some(ref count_label) = self.count_label {
-                        data.push(format!("{}/{}: {}", label, count_label, value));
-                    } else {
-                        data.push(format!("{}: {}", label, value));
-                    }
-                }
-                Output::Percentile(percentile) => match percentile {
-                    Percentile::Minimum => {
-                        data.push(format!("{}/minimum/value: {}", label, value));
-                    }
-                    Percentile::Maximum => {
-                        data.push(format!("{}/maximum/value: {}", label, value));
-                    }
-                    _ => {
-                        data.push(format!("{}/histogram/{}: {}", label, percentile, value));
-                    }
-                },
-                Output::MaxPointTime => {
-                    // we have point's ns since X and current timespec and current ns sinc X
-                    let point_ns = value;
-                    let now_timespec = time::get_time();
-                    let now_ns = time::precise_time_ns();
-
-                    // find the number of NS in the past for point
-                    let delta_ns = now_ns - point_ns;
-                    let point_timespec =
-                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
-
-                    // convert to UTC
-                    let point_utc = time::at_utc(point_timespec);
-                    // calculate offset from the top of the minute
-                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
-                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
-                    data.push(format!("{}/maximum/offset_ms: {}", label, offset_ms));
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-        data.sort();
-        let mut content = data.join("\n");
-        content += "\n";
-        content
-    }
-
-    fn json(&self, pretty: bool) -> String {
-        let mut head = "{".to_owned();
-        if pretty {
-            head += "\n  ";
-        }
-        let mut data = Vec::new();
-        for reading in &self.snapshot {
-            let label = reading.label();
-            let output = reading.output();
-            let value = reading.value();
-            match output {
-                Output::Counter => {
-                    if let Some(ref count_label) = self.count_label {
-                        data.push(format!("\"{}/{}\": {}", label, count_label, value));
-                    } else {
-                        data.push(format!("\"{}\": {}", label, value));
-                    }
-                }
-                Output::Percentile(percentile) => match percentile {
-                    Percentile::Minimum => {
-                        data.push(format!("\"{}/minimum/value\": {}", label, value));
-                    }
-                    Percentile::Maximum => {
-                        data.push(format!("\"{}/maximum/value\": {}", label, value));
-                    }
-                    _ => {
-                        data.push(format!("\"{}/histogram/{}\": {}", label, percentile, value));
-                    }
-                },
-                Output::MaxPointTime => {
-                    // we have point's ns since X and current timespec and current ns since X
-                    let point_ns = value;
-                    let now_timespec = time::get_time();
-                    let now_ns = time::precise_time_ns();
-
-                    // find the number of NS in the past for point
-                    let delta_ns = now_ns - point_ns;
-                    let point_timespec =
-                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
-
-                    // convert to UTC
-                    let point_utc = time::at_utc(point_timespec);
-                    // calculate offset from the top of the minute
-                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
-                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
-                    data.push(format!("\"{}/maximum/offset_ms\": {}", label, offset_ms));
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
-        data.sort();
-        let body = if pretty {
-            data.join(",\n  ")
-        } else {
-            data.join(",")
-        };
-        let mut content = head;
-        content += &body;
-        if pretty {
-            content += "\n";
-        }
-        content += "}";
-        content
     }
 }

--- a/src/stats/kafka.rs
+++ b/src/stats/kafka.rs
@@ -1,0 +1,49 @@
+// Copyright 2019 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use kafka::producer::{Producer, Record};
+
+use crate::config::Config;
+use crate::stats::MetricsSnapshot;
+
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use metrics::*;
+
+pub struct KafkaProducer {
+    snapshot: MetricsSnapshot,
+    producer: Producer,
+    topic: String,
+    interval: Duration,
+}
+
+impl KafkaProducer {
+    pub fn new(
+        config: Arc<Config>,
+        metrics: Metrics<AtomicU32>,
+        count_label: Option<&str>,
+    ) -> Self {
+        Self {
+            snapshot: MetricsSnapshot::new(metrics, count_label),
+            producer: Producer::from_hosts(config.kafka().hosts())
+                .create()
+                .unwrap(),
+            topic: config.kafka().topic().unwrap(),
+            interval: Duration::from_millis(config.kafka().interval().try_into().unwrap()),
+        }
+    }
+
+    pub fn run(&mut self) {
+        let start = Instant::now();
+        self.snapshot.refresh();
+        self.producer
+            .send(&Record::from_value(&self.topic, self.snapshot.json(false)));
+        let stop = Instant::now();
+        if start + self.interval > stop {
+            std::thread::sleep(self.interval - (stop - start));
+        }
+    }
+}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -5,8 +5,10 @@
 #![allow(dead_code)]
 
 mod http;
+mod kafka;
 
 pub use self::http::Http;
+pub use self::kafka::KafkaProducer;
 
 use metrics::*;
 
@@ -21,10 +23,7 @@ pub struct MetricsSnapshot {
 }
 
 impl MetricsSnapshot {
-    pub fn new(
-        metrics: Metrics<AtomicU32>,
-        count_label: Option<&str>,
-    ) -> Self {
+    pub fn new(metrics: Metrics<AtomicU32>, count_label: Option<&str>) -> Self {
         Self {
             metrics,
             snapshot: Vec::new(),
@@ -34,8 +33,8 @@ impl MetricsSnapshot {
     }
 
     pub fn refresh(&mut self) {
-            self.snapshot = self.metrics.readings();
-            self.refreshed = time::precise_time_ns();
+        self.snapshot = self.metrics.readings();
+        self.refreshed = time::precise_time_ns();
     }
 
     pub fn prometheus(&self) -> String {

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -13,6 +13,208 @@ use metrics::*;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 
+pub struct MetricsSnapshot {
+    metrics: Metrics<AtomicU32>,
+    snapshot: Vec<Reading>,
+    refreshed: u64,
+    count_label: Option<String>,
+}
+
+impl MetricsSnapshot {
+    pub fn new(
+        metrics: Metrics<AtomicU32>,
+        count_label: Option<&str>,
+    ) -> Self {
+        Self {
+            metrics,
+            snapshot: Vec::new(),
+            refreshed: 0,
+            count_label: count_label.map(std::string::ToString::to_string),
+        }
+    }
+
+    pub fn refresh(&mut self) {
+            self.snapshot = self.metrics.readings();
+            self.refreshed = time::precise_time_ns();
+    }
+
+    pub fn prometheus(&self) -> String {
+        let mut data = Vec::new();
+        for reading in &self.snapshot {
+            let label = reading.label();
+            let output = reading.output();
+            let value = reading.value();
+            match output {
+                Output::Counter => {
+                    if let Some(ref count_label) = self.count_label {
+                        data.push(format!("{}/{} {}", label, count_label, value));
+                    } else {
+                        data.push(format!("{} {}", label, value));
+                    }
+                }
+                Output::Percentile(percentile) => match percentile {
+                    Percentile::Minimum => {
+                        data.push(format!("{}/minimum/value {}", label, value));
+                    }
+                    Percentile::Maximum => {
+                        data.push(format!("{}/maximum/value {}", label, value));
+                    }
+                    _ => {
+                        data.push(format!("{}/histogram/{} {}", label, percentile, value));
+                    }
+                },
+                Output::MaxPointTime => {
+                    // we have point's ns since X and current timespec and current ns sinc X
+                    let point_ns = value;
+                    let now_timespec = time::get_time();
+                    let now_ns = time::precise_time_ns();
+
+                    // find the number of NS in the past for point
+                    let delta_ns = now_ns - point_ns;
+                    let point_timespec =
+                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
+
+                    // convert to UTC
+                    let point_utc = time::at_utc(point_timespec);
+                    // calculate offset from the top of the minute
+                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
+                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
+                    data.push(format!("{}/maximum/offset_ms {}", label, offset_ms));
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+        data.sort();
+        let mut content = data.join("\n");
+        content += "\n";
+        let parts: Vec<&str> = content.split('/').collect();
+        parts.join("_")
+    }
+
+    pub fn human(&self) -> String {
+        let mut data = Vec::new();
+        for reading in &self.snapshot {
+            let label = reading.label();
+            let output = reading.output();
+            let value = reading.value();
+            match output {
+                Output::Counter => {
+                    if let Some(ref count_label) = self.count_label {
+                        data.push(format!("{}/{}: {}", label, count_label, value));
+                    } else {
+                        data.push(format!("{}: {}", label, value));
+                    }
+                }
+                Output::Percentile(percentile) => match percentile {
+                    Percentile::Minimum => {
+                        data.push(format!("{}/minimum/value: {}", label, value));
+                    }
+                    Percentile::Maximum => {
+                        data.push(format!("{}/maximum/value: {}", label, value));
+                    }
+                    _ => {
+                        data.push(format!("{}/histogram/{}: {}", label, percentile, value));
+                    }
+                },
+                Output::MaxPointTime => {
+                    // we have point's ns since X and current timespec and current ns sinc X
+                    let point_ns = value;
+                    let now_timespec = time::get_time();
+                    let now_ns = time::precise_time_ns();
+
+                    // find the number of NS in the past for point
+                    let delta_ns = now_ns - point_ns;
+                    let point_timespec =
+                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
+
+                    // convert to UTC
+                    let point_utc = time::at_utc(point_timespec);
+                    // calculate offset from the top of the minute
+                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
+                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
+                    data.push(format!("{}/maximum/offset_ms: {}", label, offset_ms));
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+        data.sort();
+        let mut content = data.join("\n");
+        content += "\n";
+        content
+    }
+
+    fn json(&self, pretty: bool) -> String {
+        let mut head = "{".to_owned();
+        if pretty {
+            head += "\n  ";
+        }
+        let mut data = Vec::new();
+        for reading in &self.snapshot {
+            let label = reading.label();
+            let output = reading.output();
+            let value = reading.value();
+            match output {
+                Output::Counter => {
+                    if let Some(ref count_label) = self.count_label {
+                        data.push(format!("\"{}/{}\": {}", label, count_label, value));
+                    } else {
+                        data.push(format!("\"{}\": {}", label, value));
+                    }
+                }
+                Output::Percentile(percentile) => match percentile {
+                    Percentile::Minimum => {
+                        data.push(format!("\"{}/minimum/value\": {}", label, value));
+                    }
+                    Percentile::Maximum => {
+                        data.push(format!("\"{}/maximum/value\": {}", label, value));
+                    }
+                    _ => {
+                        data.push(format!("\"{}/histogram/{}\": {}", label, percentile, value));
+                    }
+                },
+                Output::MaxPointTime => {
+                    // we have point's ns since X and current timespec and current ns since X
+                    let point_ns = value;
+                    let now_timespec = time::get_time();
+                    let now_ns = time::precise_time_ns();
+
+                    // find the number of NS in the past for point
+                    let delta_ns = now_ns - point_ns;
+                    let point_timespec =
+                        now_timespec - time::Duration::nanoseconds(delta_ns as i64);
+
+                    // convert to UTC
+                    let point_utc = time::at_utc(point_timespec);
+                    // calculate offset from the top of the minute
+                    let offset = point_utc.tm_sec as u64 * 1_000_000_000 + point_utc.tm_nsec as u64;
+                    let offset_ms = (offset as f64 / 1_000_000.0).floor() as u64;
+                    data.push(format!("\"{}/maximum/offset_ms\": {}", label, offset_ms));
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+        data.sort();
+        let body = if pretty {
+            data.join(",\n  ")
+        } else {
+            data.join(",")
+        };
+        let mut content = head;
+        content += &body;
+        if pretty {
+            content += "\n";
+        }
+        content += "}";
+        content
+    }
+}
+
 pub struct StatsLog {
     file: File,
     metrics: Metrics<AtomicU32>,

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -5,9 +5,12 @@
 #![allow(dead_code)]
 
 mod http;
+#[cfg(feature = "push_kafka")]
 mod kafka;
 
 pub use self::http::Http;
+
+#[cfg(feature = "push_kafka")]
 pub use self::kafka::KafkaProducer;
 
 use metrics::*;


### PR DESCRIPTION
This adds support for pushing metrics to kafka, and additionally refactors the metrics snapshotting code out of the http server (so that the serialization code can be shared between the http server code and the kafka code).