### PR TITLE
cleanup Sampler trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,17 +68,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // spawn samplers
     debug!("spawning samplers");
-    Cpu::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Disk::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Ext4::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Memory::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Network::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Rezolus::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Scheduler::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Softnet::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Tcp::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Udp::spawn(config.clone(), metrics.clone(), runtime.handle());
-    Xfs::spawn(config.clone(), metrics.clone(), runtime.handle());
+    let common = Common::new(config.clone(), metrics.clone(), runtime.handle().clone());
+    Cpu::spawn(common.clone());
+    Disk::spawn(common.clone());
+    Ext4::spawn(common.clone());
+    Memory::spawn(common.clone());
+    Network::spawn(common.clone());
+    Rezolus::spawn(common.clone());
+    Scheduler::spawn(common.clone());
+    Softnet::spawn(common.clone());
+    Tcp::spawn(common.clone());
+    Udp::spawn(common.clone());
+    Xfs::spawn(common.clone());
 
     #[cfg(feature = "push_kafka")]
     {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -12,11 +12,10 @@ use bcc;
 use metrics::*;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::runtime::Handle;
 
 use crate::common::bpf::*;
 use crate::common::*;
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -37,14 +36,14 @@ pub struct Disk {
 impl Sampler for Disk {
     type Statistic = DiskStatistic;
 
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        let fault_tolerant = config.general().fault_tolerant();
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        let fault_tolerant = common.config.general().fault_tolerant();
 
         #[allow(unused_mut)]
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
-            common: Common::new(config, metrics),
+            common,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
@@ -56,14 +55,14 @@ impl Sampler for Disk {
         Ok(sampler)
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize disk sampler");
         } else {
             error!("failed to initialize disk sampler");

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -2,19 +2,17 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
 #[cfg(feature = "bpf")]
 use bcc;
 use metrics::*;
-use tokio::runtime::Handle;
 
 use crate::common::bpf::*;
 use crate::common::*;
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -34,14 +32,14 @@ pub struct Ext4 {
 #[async_trait]
 impl Sampler for Ext4 {
     type Statistic = Ext4Statistic;
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        let fault_tolerant = config.general().fault_tolerant();
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        let fault_tolerant = common.config.general().fault_tolerant();
 
         #[allow(unused_mut)]
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
-            common: Common::new(config, metrics),
+            common,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
@@ -53,14 +51,14 @@ impl Sampler for Ext4 {
         Ok(sampler)
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize ext4 sampler");
         } else {
             error!("failed to initialize ext4 sampler");

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::net::SocketAddr;
-use std::net::ToSocketAddrs;
-use std::sync::Arc;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 use async_trait::async_trait;
 use metrics::*;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::runtime::Handle;
 
 use crate::config::*;
 use crate::samplers::Common;
@@ -53,11 +50,11 @@ impl Memcache {
 impl Sampler for Memcache {
     type Statistic = MemcacheStatistic;
 
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        if config.samplers().memcache().endpoint().is_none() {
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        if common.config.samplers().memcache().endpoint().is_none() {
             return Err(format_err!("no memcache endpoint configured"));
         }
-        let endpoint = config.samplers().memcache().endpoint().unwrap();
+        let endpoint = common.config.samplers().memcache().endpoint().unwrap();
         let mut addrs = endpoint.to_socket_addrs().unwrap_or_else(|_| {
             fatal!("ERROR: endpoint address is malformed: {}", endpoint);
         });
@@ -66,21 +63,21 @@ impl Sampler for Memcache {
         });
         let mut ret = Self {
             address,
-            common: Common::new(config, metrics),
+            common,
             stream: None,
         };
         ret.reconnect();
         Ok(ret)
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize memcache sampler");
         } else {
             error!("failed to initialize memcache sampler");

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -3,17 +3,15 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use metrics::*;
 use regex::Regex;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::runtime::Handle;
 
 use crate::common::*;
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -34,20 +32,18 @@ pub struct Memory {
 impl Sampler for Memory {
     type Statistic = MemoryStatistic;
 
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        Ok(Self {
-            common: Common::new(config, metrics),
-        })
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        Ok(Self { common })
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize memory sampler");
         } else {
             error!("failed to initialize memory sampler");

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -3,8 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -13,11 +12,10 @@ use bcc;
 use metrics::*;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::runtime::Handle;
 
 use crate::common::bpf::*;
 use crate::common::*;
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -38,14 +36,14 @@ pub struct Network {
 impl Sampler for Network {
     type Statistic = NetworkStatistic;
 
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        let fault_tolerant = config.general().fault_tolerant();
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        let fault_tolerant = common.config.general().fault_tolerant();
 
         #[allow(unused_mut)]
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
-            common: Common::new(config, metrics),
+            common,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
@@ -57,14 +55,14 @@ impl Sampler for Network {
         Ok(sampler)
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize network sampler");
         } else {
             error!("failed to initialize network sampler");

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -3,15 +3,13 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use metrics::*;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::runtime::Handle;
 
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -28,20 +26,18 @@ pub struct Softnet {
 #[async_trait]
 impl Sampler for Softnet {
     type Statistic = SoftnetStatistic;
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        Ok(Self {
-            common: Common::new(config, metrics),
-        })
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        Ok(Self { common })
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize softnet sampler");
         } else {
             error!("failed to initialize softnet sampler");

--- a/src/samplers/udp/mod.rs
+++ b/src/samplers/udp/mod.rs
@@ -2,13 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use metrics::*;
-use tokio::runtime::Handle;
 
-use crate::config::{Config, SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -27,20 +24,18 @@ pub struct Udp {
 impl Sampler for Udp {
     type Statistic = UdpStatistic;
 
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        Ok(Self {
-            common: Common::new(config, metrics),
-        })
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        Ok(Self { common })
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize udp sampler");
         } else {
             error!("failed to initialize udp sampler");

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -6,15 +6,13 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
-use atomics::AtomicU32;
 #[cfg(feature = "bpf")]
 use bcc;
 use metrics::*;
-use tokio::runtime::Handle;
 
 use crate::common::bpf::*;
 use crate::common::*;
-use crate::config::{Config, SamplerConfig};
+use crate::config::{SamplerConfig};
 use crate::samplers::Common;
 use crate::Sampler;
 
@@ -34,14 +32,14 @@ pub struct Xfs {
 #[async_trait]
 impl Sampler for Xfs {
     type Statistic = XfsStatistic;
-    fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Result<Self, failure::Error> {
-        let fault_tolerant = config.general().fault_tolerant();
+    fn new(common: Common) -> Result<Self, failure::Error> {
+        let fault_tolerant = common.config.general().fault_tolerant();
 
         #[allow(unused_mut)]
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
-            common: Common::new(config, metrics),
+            common,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
@@ -53,14 +51,14 @@ impl Sampler for Xfs {
         Ok(sampler)
     }
 
-    fn spawn(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>, handle: &Handle) {
-        if let Ok(mut sampler) = Self::new(config.clone(), metrics) {
-            handle.spawn(async move {
+    fn spawn(common: Common) {
+        if let Ok(mut sampler) = Self::new(common.clone()) {
+            common.handle.spawn(async move {
                 loop {
                     let _ = sampler.sample().await;
                 }
             });
-        } else if !config.fault_tolerant() {
+        } else if !common.config.fault_tolerant() {
             fatal!("failed to initialize xfs sampler");
         } else {
             error!("failed to initialize xfs sampler");

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -12,7 +12,7 @@ use metrics::*;
 
 use crate::common::bpf::*;
 use crate::common::*;
-use crate::config::{SamplerConfig};
+use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
 


### PR DESCRIPTION
Cleanup the Sampler trait by passing `Common` to both `spawn` and
`new`. This allows us to make changes to `Common` without having
to change the function signatures.
