### PR TITLE
enable all statistics by default

### DIFF
--- a/src/samplers/cpu/config.rs
+++ b/src/samplers/cpu/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,11 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<CpuStatistic> {
-    vec![
-        CpuStatistic::UsageUser,
-        CpuStatistic::UsageSystem,
-        CpuStatistic::UsageIdle,
-    ]
+    CpuStatistic::iter().collect()
 }
 
 impl SamplerConfig for CpuConfig {

--- a/src/samplers/cpu/stat.rs
+++ b/src/samplers/cpu/stat.rs
@@ -10,10 +10,20 @@ use metrics::Statistic;
 pub use perfcnt::linux::*;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum CpuStatistic {

--- a/src/samplers/disk/config.rs
+++ b/src/samplers/disk/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,22 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<DiskStatistic> {
-    vec![
-        DiskStatistic::BandwidthDiscard,
-        DiskStatistic::BandwidthRead,
-        DiskStatistic::BandwidthWrite,
-        DiskStatistic::OperationsDiscard,
-        DiskStatistic::OperationsRead,
-        DiskStatistic::OperationsWrite,
-        DiskStatistic::LatencyRead,
-        DiskStatistic::LatencyWrite,
-        DiskStatistic::DeviceLatencyRead,
-        DiskStatistic::DeviceLatencyWrite,
-        DiskStatistic::QueueLatencyRead,
-        DiskStatistic::QueueLatencyWrite,
-        DiskStatistic::IoSizeRead,
-        DiskStatistic::IoSizeWrite,
-    ]
+    DiskStatistic::iter().collect()
 }
 
 impl SamplerConfig for DiskConfig {

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum DiskStatistic {

--- a/src/samplers/ext4/config.rs
+++ b/src/samplers/ext4/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,12 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<Ext4Statistic> {
-    vec![
-        Ext4Statistic::ReadLatency,
-        Ext4Statistic::WriteLatency,
-        Ext4Statistic::OpenLatency,
-        Ext4Statistic::FsyncLatency,
-    ]
+    Ext4Statistic::iter().collect()
 }
 
 impl SamplerConfig for Ext4Config {

--- a/src/samplers/ext4/stat.rs
+++ b/src/samplers/ext4/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum Ext4Statistic {

--- a/src/samplers/memory/config.rs
+++ b/src/samplers/memory/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -44,24 +45,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<MemoryStatistic> {
-    vec![
-        MemoryStatistic::Total,
-        MemoryStatistic::Free,
-        MemoryStatistic::Available,
-        MemoryStatistic::Buffers,
-        MemoryStatistic::Cached,
-        MemoryStatistic::Active,
-        MemoryStatistic::Inactive,
-        MemoryStatistic::Unevictable,
-        MemoryStatistic::HardwareCorrupted,
-        MemoryStatistic::AnonHugePages,
-        MemoryStatistic::HugePagesTotal,
-        MemoryStatistic::HugePagesFree,
-        MemoryStatistic::HugePagesRsvd,
-        MemoryStatistic::HugePagesSurp,
-        MemoryStatistic::Hugepagesize,
-        MemoryStatistic::Hugetlb,
-    ]
+    MemoryStatistic::iter().collect()
 }
 
 impl SamplerConfig for MemoryConfig {

--- a/src/samplers/memory/stat.rs
+++ b/src/samplers/memory/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum MemoryStatistic {

--- a/src/samplers/network/config.rs
+++ b/src/samplers/network/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,27 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<NetworkStatistic> {
-    vec![
-        NetworkStatistic::ReceiveBytes,
-        NetworkStatistic::ReceivePackets,
-        NetworkStatistic::ReceiveErrors,
-        NetworkStatistic::ReceiveDrops,
-        NetworkStatistic::ReceiveFifo,
-        NetworkStatistic::ReceiveFrame,
-        NetworkStatistic::ReceiveCompressed,
-        NetworkStatistic::ReceiveMulticast,
-        NetworkStatistic::ReceiveBytes,
-        NetworkStatistic::TransmitBytes,
-        NetworkStatistic::TransmitPackets,
-        NetworkStatistic::TransmitErrors,
-        NetworkStatistic::TransmitDrops,
-        NetworkStatistic::TransmitFifo,
-        NetworkStatistic::TransmitCollisions,
-        NetworkStatistic::TransmitCarrier,
-        NetworkStatistic::TransmitCompressed,
-        NetworkStatistic::ReceiveSize,
-        NetworkStatistic::TransmitSize,
-    ]
+    NetworkStatistic::iter().collect()
 }
 
 impl SamplerConfig for NetworkConfig {

--- a/src/samplers/network/stat.rs
+++ b/src/samplers/network/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum NetworkStatistic {

--- a/src/samplers/rezolus/config.rs
+++ b/src/samplers/rezolus/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -44,12 +45,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<RezolusStatistic> {
-    vec![
-        RezolusStatistic::CpuUser,
-        RezolusStatistic::CpuSystem,
-        RezolusStatistic::MemoryResident,
-        RezolusStatistic::MemoryVirtual,
-    ]
+    RezolusStatistic::iter().collect()
 }
 
 impl SamplerConfig for RezolusConfig {

--- a/src/samplers/rezolus/stat.rs
+++ b/src/samplers/rezolus/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum RezolusStatistic {

--- a/src/samplers/scheduler/config.rs
+++ b/src/samplers/scheduler/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -50,14 +51,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<SchedulerStatistic> {
-    vec![
-        SchedulerStatistic::ContextSwitches,
-        SchedulerStatistic::CpuMigrations,
-        SchedulerStatistic::ProcessesBlocked,
-        SchedulerStatistic::ProcessesCreated,
-        SchedulerStatistic::ProcessesRunning,
-        SchedulerStatistic::RunqueueLatency,
-    ]
+    SchedulerStatistic::iter().collect()
 }
 
 impl SamplerConfig for SchedulerConfig {

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -10,10 +10,20 @@ use metrics::{Source, Statistic};
 pub use perfcnt::linux::*;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum SchedulerStatistic {

--- a/src/samplers/softnet/config.rs
+++ b/src/samplers/softnet/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -44,14 +45,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<SoftnetStatistic> {
-    vec![
-        SoftnetStatistic::Processed,
-        SoftnetStatistic::Dropped,
-        SoftnetStatistic::TimeSqueezed,
-        SoftnetStatistic::CpuCollision,
-        SoftnetStatistic::ReceivedRps,
-        SoftnetStatistic::FlowLimitCount,
-    ]
+    SoftnetStatistic::iter().collect()
 }
 
 impl SamplerConfig for SoftnetConfig {

--- a/src/samplers/softnet/stat.rs
+++ b/src/samplers/softnet/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum SoftnetStatistic {

--- a/src/samplers/tcp/config.rs
+++ b/src/samplers/tcp/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,25 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<TcpStatistic> {
-    vec![
-        TcpStatistic::ConnectLatency,
-        TcpStatistic::ReceiveChecksumErrors,
-        TcpStatistic::ReceiveCollapsed,
-        TcpStatistic::ReceiveErrors,
-        TcpStatistic::ReceiveListenOverflows,
-        TcpStatistic::ReceiveListenDrops,
-        TcpStatistic::ReceiveOfoPruned,
-        TcpStatistic::ReceivePruneCalled,
-        TcpStatistic::ReceivePruned,
-        TcpStatistic::ReceiveSegments,
-        TcpStatistic::Retransmits,
-        TcpStatistic::SyncookiesSent,
-        TcpStatistic::SyncookiesRecieved,
-        TcpStatistic::SyncookiesFailed,
-        TcpStatistic::TransmitDelayedAcks,
-        TcpStatistic::TransmitResets,
-        TcpStatistic::TransmitSegments,
-    ]
+    TcpStatistic::iter().collect()
 }
 
 impl SamplerConfig for TcpConfig {

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum TcpStatistic {

--- a/src/samplers/udp/config.rs
+++ b/src/samplers/udp/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -42,12 +43,9 @@ fn default_percentiles() -> Vec<Percentile> {
         Percentile::p99,
     ]
 }
+
 fn default_statistics() -> Vec<UdpStatistic> {
-    vec![
-        UdpStatistic::InDatagrams,
-        UdpStatistic::InErrors,
-        UdpStatistic::OutDatagrams,
-    ]
+    UdpStatistic::iter().collect()
 }
 
 impl SamplerConfig for UdpConfig {

--- a/src/samplers/udp/stat.rs
+++ b/src/samplers/udp/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum UdpStatistic {

--- a/src/samplers/xfs/config.rs
+++ b/src/samplers/xfs/config.rs
@@ -4,6 +4,7 @@
 
 use metrics::*;
 use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
 
 use crate::config::SamplerConfig;
 
@@ -47,12 +48,7 @@ fn default_percentiles() -> Vec<Percentile> {
 }
 
 fn default_statistics() -> Vec<XfsStatistic> {
-    vec![
-        XfsStatistic::FsyncLatency,
-        XfsStatistic::OpenLatency,
-        XfsStatistic::ReadLatency,
-        XfsStatistic::WriteLatency,
-    ]
+    XfsStatistic::iter().collect()
 }
 
 impl SamplerConfig for XfsConfig {

--- a/src/samplers/xfs/stat.rs
+++ b/src/samplers/xfs/stat.rs
@@ -8,10 +8,20 @@ use core::str::FromStr;
 use metrics::Statistic;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[derive(
-    Clone, Copy, Debug, Deserialize, EnumString, Eq, IntoStaticStr, PartialEq, Hash, Serialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
 )]
 #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
 pub enum XfsStatistic {


### PR DESCRIPTION
Currently, we need to add new statistics to the
`default_statistics` method in each sampler config. This creates
an opportunity to miss statistics and makes the configuration
verbose when we want to expose the full set of statistics for each
sampler.

By using the strum enum iterator functionality, we can make all
statistics enabled by default. Users will still need to enable each
sampler, bpf, and perf functionality as desired for their
environment. But this change provides a more reasonable default
behavior for handling which statistics would be exposed if they are
collected.
