### PR TITLE
add cfs throttled time distribution

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -267,6 +267,7 @@ Provides telemetry about the Linux Scheduler
 
 ### eBPF
 
+* `scheduler/cfs/throttled` - the distribution of time cgroups spent throttled
 * `scheduler/runqueue/latency` - the distribution of time that runnable tasks
   were waiting on the runqueue
 

--- a/src/samplers/scheduler/bpf.c
+++ b/src/samplers/scheduler/bpf.c
@@ -15,10 +15,12 @@ typedef struct pidns_key {
     u64 slot;
 } pidns_key_t;
 
-BPF_TABLE("hash", u32, u64, start, 65536);
+BPF_TABLE("hash", u32, u64, runqueue_start, 65536);
+BPF_HASH(throttle_start, int);
 
 // value_to_index() gives us from 0-460 as the index
 BPF_HISTOGRAM(runqueue_latency, int, 461);
+BPF_HISTOGRAM(cfs_throttle, int, 461);
 
 struct rq;
 
@@ -32,10 +34,217 @@ struct sched_wakeup_arg {
     int target_cpu;
 };
 
+typedef struct cgroup_key {
+    char name[64];
+} cgroup_key_t;
+
+/* type-specific structures for kernfs_node union members */
+struct kernfs_elem_dir {
+    unsigned long       subdirs;
+    /* children rbtree starts here and goes through kn->rb */
+    struct rb_root      children;
+
+    /*
+     * The kernfs hierarchy this directory belongs to.  This fits
+     * better directly in kernfs_node but is here to save space.
+     */
+    struct kernfs_root  *root;
+};
+
+struct kernfs_elem_symlink {
+    struct kernfs_node  *target_kn;
+};
+
+struct kernfs_elem_attr {
+    const struct kernfs_ops *ops;
+    struct kernfs_open_node *open;
+    loff_t          size;
+    struct kernfs_node  *notify_next;   /* for kernfs_notify() */
+};
+
+
+struct kernfs_node {
+    atomic_t        count;
+    atomic_t        active;
+
+    /*
+     * Use kernfs_get_parent() and kernfs_name/path() instead of
+     * accessing the following two fields directly.  If the node is
+     * never moved to a different parent, it is safe to access the
+     * parent directly.
+     */
+    struct kernfs_node  *parent;
+    const char      *name;
+
+    struct rb_node      rb;
+
+    const void      *ns;    /* namespace tag */
+    unsigned int        hash;   /* ns + name hash */
+    union {
+        struct kernfs_elem_dir      dir;
+        struct kernfs_elem_symlink  symlink;
+        struct kernfs_elem_attr     attr;
+    };
+
+    void            *priv;
+
+    /*
+     * 64bit unique ID.  On 64bit ino setups, id is the ino.  On 32bit,
+     * the low 32bits are ino and upper generation.
+     */
+    u64         id;
+
+    unsigned short      flags;
+    umode_t         mode;
+    struct kernfs_iattrs    *iattr;
+};
+
+struct rt_bandwidth {
+    /* nests inside the rq lock: */
+    raw_spinlock_t      rt_runtime_lock;
+    ktime_t         rt_period;
+    u64         rt_runtime;
+    struct hrtimer      rt_period_timer;
+    unsigned int        rt_period_active;
+};
+
+struct cfs_bandwidth {
+    raw_spinlock_t      lock;
+    ktime_t         period;
+    u64         quota;
+    u64         runtime;
+    s64         hierarchical_quota;
+
+    u8          idle;
+    u8          period_active;
+    u8          distribute_running;
+    u8          slack_started;
+    struct hrtimer      period_timer;
+    struct hrtimer      slack_timer;
+    struct list_head    throttled_cfs_rq;
+
+    /* Statistics: */
+    int         nr_periods;
+    int         nr_throttled;
+    u64         throttled_time;
+};
+
+/* Task group related information */
+struct task_group {
+    struct cgroup_subsys_state css;
+
+    /* schedulable entities of this group on each CPU */
+    struct sched_entity **se;
+    /* runqueue "owned" by this group on each CPU */
+    struct cfs_rq       **cfs_rq;
+    unsigned long       shares;
+
+    /*
+     * load_avg can be heavily contended at clock tick time, so put
+     * it in its own cacheline separated from the fields above which
+     * will also be accessed at each tick.
+     */
+    atomic_long_t       load_avg ____cacheline_aligned;
+
+    struct sched_rt_entity  **rt_se;
+    struct rt_rq        **rt_rq;
+
+    struct rt_bandwidth rt_bandwidth;
+
+    struct rcu_head     rcu;
+    struct list_head    list;
+
+    struct task_group   *parent;
+    struct list_head    siblings;
+    struct list_head    children;
+
+    struct autogroup    *autogroup;
+
+    struct cfs_bandwidth    cfs_bandwidth;
+};
+
+/* CFS-related fields in a runqueue */
+struct cfs_rq {
+    struct load_weight  load;
+    unsigned long       runnable_weight;
+    unsigned int        nr_running;
+    unsigned int        h_nr_running;      /* SCHED_{NORMAL,BATCH,IDLE} */
+    unsigned int        idle_h_nr_running; /* SCHED_IDLE */
+
+    u64         exec_clock;
+    u64         min_vruntime;
+    u64         min_vruntime_copy;
+
+    struct rb_root_cached   tasks_timeline;
+
+    /*
+     * 'curr' points to currently running entity on this cfs_rq.
+     * It is set to NULL otherwise (i.e when none are currently running).
+     */
+    struct sched_entity *curr;
+    struct sched_entity *next;
+    struct sched_entity *last;
+    struct sched_entity *skip;
+
+    unsigned int        nr_spread_over;
+
+    /*
+     * CFS load tracking
+     */
+    struct sched_avg    avg;
+    u64         load_last_update_time_copy;
+    struct {
+        raw_spinlock_t  lock ____cacheline_aligned;
+        int     nr;
+        unsigned long   load_avg;
+        unsigned long   util_avg;
+        unsigned long   runnable_sum;
+    } removed;
+
+    unsigned long       tg_load_avg_contrib;
+    long            propagate;
+    long            prop_runnable_sum;
+
+    /*
+     *   h_load = weight * f(tg)
+     *
+     * Where f(tg) is the recursive weight fraction assigned to
+     * this group.
+     */
+    unsigned long       h_load;
+    u64         last_h_load_update;
+    struct sched_entity *h_load_next;
+
+    struct rq       *rq;    /* CPU runqueue to which this cfs_rq is attached */
+
+    /*
+     * leaf cfs_rqs are those that hold tasks (lowest schedulable entity in
+     * a hierarchy). Non-leaf lrqs hold other higher schedulable entities
+     * (like users, containers etc.)
+     *
+     * leaf_cfs_rq_list ties together list of leaf cfs_rq's in a CPU.
+     * This list is used during load balance.
+     */
+    int         on_list;
+    struct list_head    leaf_cfs_rq_list;
+    struct task_group   *tg;    /* group that "owns" this runqueue */
+
+    int         runtime_enabled;
+    s64         runtime_remaining;
+
+    u64         throttled_clock;
+    u64         throttled_clock_task;
+    u64         throttled_clock_task_time;
+    int         throttled;
+    int         throttle_count;
+    struct list_head    throttled_list;
+};
+
+
 static int trace_enqueue(u32 tgid, u32 pid)
 {
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    runqueue_start.update(&pid, &ts);
     return 0;
 }
 
@@ -103,7 +312,7 @@ int trace_run(struct pt_regs *ctx, struct task_struct *prev)
         u32 tgid = prev->tgid;
         u32 pid = prev->pid;
         u64 ts = bpf_ktime_get_ns();
-        start.update(&pid, &ts);
+        runqueue_start.update(&pid, &ts);
     }
 
     // get tgid and pid
@@ -111,7 +320,7 @@ int trace_run(struct pt_regs *ctx, struct task_struct *prev)
     u32 pid = bpf_get_current_pid_tgid();
 
     // lookup start time
-    u64 *tsp = start.lookup(&pid);
+    u64 *tsp = runqueue_start.lookup(&pid);
 
     // skip events with unknown start
     if (tsp == 0) {
@@ -126,6 +335,35 @@ int trace_run(struct pt_regs *ctx, struct task_struct *prev)
     runqueue_latency.increment(index);
 
     // clear the start time
-    start.delete(&pid);
+    runqueue_start.delete(&pid);
     return 0;
 }
+
+int trace_throttle(struct pt_regs *ctx, struct cfs_rq *cfs_rq)
+{
+    // key is the id of the kernelfs_node for the cgroup being throttled
+    int id = cfs_rq->tg->css.cgroup->kn->id;
+    u64 ts = bpf_ktime_get_ns();
+    throttle_start.update(&id, &ts);
+    return 0;
+};
+
+int trace_unthrottle(struct pt_regs *ctx, struct cfs_rq *cfs_rq)
+{
+    // key is the id of the kernelfs_node for the cgroup being unthrottled
+    int id = cfs_rq->tg->css.cgroup->kn->id;
+    u64 *tsp;
+    const u64 microsecond = 1000;
+    
+    tsp = start.lookup(&id);
+    if (tsp == 0) {
+        // missed throttle, skip
+        return 0;
+    }
+    int delta = bpf_ktime_get_ns() - *tsp;
+    delta /= microsecond;
+    int index = value_to_index2(delta);
+    cfs_throttle.increment(index);
+    throttle_start.delete(&id);
+    return 0;
+};

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -289,7 +289,11 @@ impl Scheduler {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                if self.sampler_config().statistics().contains(SchedulerStatistic::RunqueueLatency) {
+                if self
+                    .sampler_config()
+                    .statistics()
+                    .contains(&SchedulerStatistic::RunqueueLatency)
+                {
                     let trace_run = bpf.load_kprobe("trace_run")?;
                     let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup")?;
                     let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task")?;
@@ -299,14 +303,18 @@ impl Scheduler {
                     bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)?;
                 }
 
-                if self.sampler_config().statistics().contains(SchedulerStatistic::CfsThrottled) {
+                if self
+                    .sampler_config()
+                    .statistics()
+                    .contains(&SchedulerStatistic::CfsThrottled)
+                {
                     let trace_throttle = bpf.load_kprobe("trace_throttle")?;
                     let trace_unthrottle = bpf.load_kprobe("trace_unthrottle")?;
-                    
+
                     bpf.attach_kprobe("throttle_cfs_rq", trace_throttle)?;
                     bpf.attach_kprobe("unthrottle_cfs_rq", trace_unthrottle)?;
                 }
-                
+
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -285,19 +285,28 @@ impl Scheduler {
         {
             if self.enabled() && self.bpf_enabled() {
                 debug!("initializing bpf");
-                // load the code and compile
+
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                // load + attach kprobes!
-                let trace_run = bpf.load_kprobe("trace_run")?;
-                let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup")?;
-                let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task")?;
+                if self.sampler_config().statistics().contains(SchedulerStatistic::RunqueueLatency) {
+                    let trace_run = bpf.load_kprobe("trace_run")?;
+                    let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup")?;
+                    let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task")?;
 
-                bpf.attach_kprobe("finish_task_switch", trace_run)?;
-                bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)?;
-                bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)?;
+                    bpf.attach_kprobe("finish_task_switch", trace_run)?;
+                    bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)?;
+                    bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)?;
+                }
 
+                if self.sampler_config().statistics().contains(SchedulerStatistic::CfsThrottled) {
+                    let trace_throttle = bpf.load_kprobe("trace_throttle")?;
+                    let trace_unthrottle = bpf.load_kprobe("trace_unthrottle")?;
+                    
+                    bpf.attach_kprobe("throttle_cfs_rq", trace_throttle)?;
+                    bpf.attach_kprobe("unthrottle_cfs_rq", trace_unthrottle)?;
+                }
+                
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -29,6 +29,8 @@ use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 pub enum SchedulerStatistic {
     #[strum(serialize = "scheduler/cpu_migrations")]
     CpuMigrations,
+    #[strum(serialize = "scheduler/cfs/throttled")]
+    CfsThrottled,
     #[strum(serialize = "scheduler/runqueue/latency")]
     RunqueueLatency,
     #[strum(serialize = "scheduler/context_switches")]
@@ -45,6 +47,7 @@ impl SchedulerStatistic {
     #[allow(dead_code)]
     pub fn bpf_table(self) -> Option<&'static str> {
         match self {
+            Self::CfsThrottled => Some("cfs_throttled"),
             Self::RunqueueLatency => Some("runqueue_latency"),
             _ => None,
         }
@@ -68,7 +71,7 @@ impl Statistic for SchedulerStatistic {
 
     fn source(&self) -> Source {
         match *self {
-            Self::RunqueueLatency => Source::Distribution,
+            Self::RunqueueLatency | Self::CfsThrottled => Source::Distribution,
             Self::ProcessesRunning | Self::ProcessesBlocked => Source::Gauge,
             _ => Source::Counter,
         }


### PR DESCRIPTION
We want to be able to track the amount of time cgroups are
throttled by CFS.

Adds additional BPF telemetry to measure the delta between
throttle and unthrottle. Tracks per-cgroup and increments a
histogram of host-wide throttled time distribution.

Can be enabled with or without the runqueue latency BPF.
