### PR TITLE
bugfix: error handling

### DIFF
--- a/configs/ci.toml
+++ b/configs/ci.toml
@@ -4,8 +4,8 @@ listen = "0.0.0.0:4242"
 
 [samplers]
 [samplers.cpu]
-enabled = true
-perf_events = true
+enabled = false
+perf_events = false
 
 [samplers.disk]
 bpf = true
@@ -27,6 +27,7 @@ enabled = true
 
 [samplers.scheduler]
 bpf = true
+enabled = true
 perf_events = true
 
 [samplers.softnet]
@@ -40,6 +41,5 @@ enabled = true
 enabled = true
 
 [samplers.xfs]
-# no xfs present on ci
-# bpf = true
+bpf = false # no xfs present on ci, keep BPF disabled
 enabled = true

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -105,7 +105,6 @@ impl Sampler for Memcache {
             return Ok(());
         }
 
-        debug!("sampling");
         if let Some(ref mut stream) = self.stream {
             stream.write_all(b"stats\r\n").await?;
             let mut buffer = [0_u8; 16355];

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -74,7 +74,7 @@ impl Sampler for Memory {
         debug!("sampling");
         self.register();
 
-        self.sample_meminfo().await?;
+        self.map_result(self.sample_meminfo().await)?;
 
         Ok(())
     }

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -104,6 +104,23 @@ pub trait Sampler: Sized + Send {
     fn metrics(&self) -> &Metrics<AtomicU32> {
         self.common().metrics()
     }
+
+    /// Used to map errors according to fault tolerance
+    /// WouldBlock is returned as-is so that async/await behaves as expected
+    /// All other errors are handled per fault tolerance setting
+    fn map_result(&self, result: Result<(), std::io::Error>) -> Result<(), std::io::Error> {
+        if let Err(e) = result {
+            if e.kind() == std::io::ErrorKind::WouldBlock {
+                return Err(e);
+            }
+            if self.common().config().general().fault_tolerant() {
+                debug!("error: {}", e);
+            } else {
+                fatal!("error: {}", e);
+            }
+        }
+        Ok(())
+    }
 }
 
 pub struct Common {

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -77,8 +77,8 @@ impl Sampler for Rezolus {
         }
 
         debug!("sampling");
-        self.sample_memory().await?;
-        self.sample_cpu().await?;
+        self.map_result(self.sample_memory().await)?;
+        self.map_result(self.sample_cpu().await)?;
 
         Ok(())
     }

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -68,6 +68,22 @@ impl Sampler for Softnet {
         debug!("sampling");
         self.register();
 
+        self.map_result(self.sample_softnet_stats().await)?;
+
+        Ok(())
+    }
+
+    fn summary(&self, _statistic: &Self::Statistic) -> Option<Summary> {
+        Some(Summary::histogram(
+            1_000_000_000_000,
+            3,
+            Some(self.general_config().window()),
+        ))
+    }
+}
+
+impl Softnet {
+    async fn sample_softnet_stats(&self) -> Result<(), std::io::Error> {
         let file = File::open("/proc/net/softnet_stat").await?;
         let reader = BufReader::new(file);
         let mut lines = reader.lines();
@@ -94,13 +110,5 @@ impl Sampler for Softnet {
         }
 
         Ok(())
-    }
-
-    fn summary(&self, _statistic: &Self::Statistic) -> Option<Summary> {
-        Some(Summary::histogram(
-            1_000_000_000_000,
-            3,
-            Some(self.general_config().window()),
-        ))
     }
 }

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -87,61 +87,12 @@ impl Sampler for Tcp {
         debug!("sampling");
         self.register();
 
-        // sample /proc/net/snmp
-        if let Ok(snmp) = crate::common::nested_map_from_file("/proc/net/snmp").await {
-            let time = time::precise_time_ns();
-            for statistic in self.sampler_config().statistics() {
-                if let Some((pkey, lkey)) = statistic.keys() {
-                    if let Some(inner) = snmp.get(pkey) {
-                        if let Some(value) = inner.get(lkey) {
-                            self.metrics().record_counter(statistic, time, *value);
-                        }
-                    }
-                }
-            }
-        }
-
-        // sample /proc/net/netstat
-        if let Ok(netstat) = crate::common::nested_map_from_file("/proc/net/netstat").await {
-            let time = time::precise_time_ns();
-            for statistic in self.sampler_config().statistics() {
-                if let Some((pkey, lkey)) = statistic.keys() {
-                    if let Some(inner) = netstat.get(pkey) {
-                        if let Some(value) = inner.get(lkey) {
-                            self.metrics().record_counter(statistic, time, *value);
-                        }
-                    }
-                }
-            }
-        }
+        self.map_result(self.sample_snmp().await)?;
+        self.map_result(self.sample_netstat().await)?;
 
         // sample bpf
         #[cfg(feature = "bpf")]
-        {
-            if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
-                if let Some(ref bpf) = self.bpf {
-                    let bpf = bpf.lock().unwrap();
-                    let time = time::precise_time_ns();
-                    for statistic in self.sampler_config().statistics() {
-                        if let Some(table) = statistic.bpf_table() {
-                            let mut table = (*bpf).inner.table(table);
-
-                            for (&value, &count) in &map_from_table(&mut table) {
-                                if count > 0 {
-                                    self.metrics().record_distribution(
-                                        statistic,
-                                        time,
-                                        value * 1000,
-                                        count,
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-                *self.bpf_last.lock().unwrap() = Instant::now();
-            }
-        }
+        self.map_result(self.sample_bpf())?;
 
         Ok(())
     }
@@ -202,6 +153,64 @@ impl Tcp {
             }
         }
 
+        Ok(())
+    }
+
+    async fn sample_snmp(&self) -> Result<(), std::io::Error> {
+        let snmp = crate::common::nested_map_from_file("/proc/net/snmp").await?;
+        let time = time::precise_time_ns();
+        for statistic in self.sampler_config().statistics() {
+            if let Some((pkey, lkey)) = statistic.keys() {
+                if let Some(inner) = snmp.get(pkey) {
+                    if let Some(value) = inner.get(lkey) {
+                        self.metrics().record_counter(statistic, time, *value);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn sample_netstat(&self) -> Result<(), std::io::Error> {
+        let netstat = crate::common::nested_map_from_file("/proc/net/netstat").await?;
+        let time = time::precise_time_ns();
+        for statistic in self.sampler_config().statistics() {
+            if let Some((pkey, lkey)) = statistic.keys() {
+                if let Some(inner) = netstat.get(pkey) {
+                    if let Some(value) = inner.get(lkey) {
+                        self.metrics().record_counter(statistic, time, *value);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "bpf")]
+    fn sample_bpf(&self) -> Result<(), std::io::Error> {
+        if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
+            if let Some(ref bpf) = self.bpf {
+                let bpf = bpf.lock().unwrap();
+                let time = time::precise_time_ns();
+                for statistic in self.sampler_config().statistics() {
+                    if let Some(table) = statistic.bpf_table() {
+                        let mut table = (*bpf).inner.table(table);
+
+                        for (&value, &count) in &map_from_table(&mut table) {
+                            if count > 0 {
+                                self.metrics().record_distribution(
+                                    statistic,
+                                    time,
+                                    value * 1000,
+                                    count,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            *self.bpf_last.lock().unwrap() = Instant::now();
+        }
         Ok(())
     }
 }

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -91,31 +91,7 @@ impl Sampler for Xfs {
 
         // sample bpf
         #[cfg(feature = "bpf")]
-        {
-            if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
-                if let Some(ref bpf) = self.bpf {
-                    let bpf = bpf.lock().unwrap();
-                    let time = time::precise_time_ns();
-                    for statistic in self.sampler_config().statistics() {
-                        if let Some(table) = statistic.bpf_table() {
-                            let mut table = (*bpf).inner.table(table);
-
-                            for (&value, &count) in &map_from_table(&mut table) {
-                                if count > 0 {
-                                    self.metrics().record_distribution(
-                                        statistic,
-                                        time,
-                                        value * MICROSECOND,
-                                        count,
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-                *self.bpf_last.lock().unwrap() = Instant::now();
-            }
-        }
+        self.map_result(self.sample_bpf())?;
 
         Ok(())
     }
@@ -176,6 +152,34 @@ impl Xfs {
             }
         }
 
+        Ok(())
+    }
+
+    #[cfg(feature = "bpf")]
+    fn sample_bpf(&self) -> Result<(), std::io::Error> {
+        if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
+            if let Some(ref bpf) = self.bpf {
+                let bpf = bpf.lock().unwrap();
+                let time = time::precise_time_ns();
+                for statistic in self.sampler_config().statistics() {
+                    if let Some(table) = statistic.bpf_table() {
+                        let mut table = (*bpf).inner.table(table);
+
+                        for (&value, &count) in &map_from_table(&mut table) {
+                            if count > 0 {
+                                self.metrics().record_distribution(
+                                    statistic,
+                                    time,
+                                    value * MICROSECOND,
+                                    count,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            *self.bpf_last.lock().unwrap() = Instant::now();
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Problem

Currently, when a sampler is composed of multiple async functions,
an earlier failure that is not `WouldBlock` will cause the sampler
to abort early. An example of this is in the cpu sampler, where a
`NotFound` error in the cstate sampling would lead to cpu usage
sampling being skipped.

Solution

To fix this issue, a new `map_result()` function is added to the
sampler trait which is used to map the result type and return a
`WouldBlock` directly or apply error handling logic per the fault
tolerance setting in the config.

Result

The result is that, when a `WouldBlock` is raised, the async/await
semantics are as expected and the sampler will resume when ready.
When other errors are encountered, a debug message or fatal error
will be raised depending on fault tolerance setting.