### PR TITLE
fix typo in example config

### DIFF
--- a/configs/example.toml
+++ b/configs/example.toml
@@ -38,7 +38,7 @@ percentiles = [
 bpf = true
 enabled = true
 
-[samplers.interrupts]
+[samplers.interrupt]
 enabled = true
 
 [samplers.memory]


### PR DESCRIPTION
Fixes typo in example config
