### PR TITLE
increase max for context switch histogram

### DIFF
--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -153,14 +153,8 @@ impl Sampler for Scheduler {
             3
         };
 
-        let max = if statistic.bpf_table().is_some() {
-            SECOND
-        } else {
-            1_000_000
-        };
-
         Some(Summary::histogram(
-            max,
+            statistic.max(),
             precision,
             Some(self.general_config().window()),
         ))

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::common::SECOND;
 use core::convert::TryFrom;
 use core::str::FromStr;
 
@@ -57,6 +58,18 @@ impl SchedulerStatistic {
                 SoftwareEventType::CpuMigrations,
             )),
             _ => None,
+        }
+    }
+
+    pub fn max(&self) -> u64 {
+        if self.bpf_table().is_some() {
+            SECOND
+        } else {
+            if *self == SchedulerStatistic::ContextSwitches {
+                1_000_000_000
+            } else {
+                1_000_000
+            }
         }
     }
 }


### PR DESCRIPTION
Problem

The current max of `1_000_000` can be exceeded for the context switch metrics for some workloads.

Solution

Moves the max into a function on the statistic and increase the max for context switch to `1_000_000_000`

Result

Summary metrics for cswitch/s should be unlikely to max out the histogram with the new limit.
