### PR TITLE
fixes for asm syntax changes in nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,174 +1,151 @@
 language: rust
 sudo: required
 cache: cargo
+rust: nightly-2020-05-01
 matrix:
   fast_finish: true
   include:
     - name: "default: xenial / nightly"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1
       script:
         - bash build/ci.sh
     - name: "default: bionic / nightly"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.8.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.8.0" FEATURES="bpf_v0_8_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.9.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.9.0" FEATURES="bpf_v0_9_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.10.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.10.0" FEATURES="bpf_v0_10_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.11.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.11.0" FEATURES="bpf_v0_11_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.12.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.12.0" FEATURES="bpf_v0_12_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc 0.13.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="0.13.0" FEATURES="bpf_v0_13_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 8 / bcc latest"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="latest" FEATURES="bpf"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.8.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.8.0" FEATURES="bpf_v0_8_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.9.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.9.0" FEATURES="bpf_v0_9_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.10.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.10.0" FEATURES="bpf_v0_10_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.11.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.11.0" FEATURES="bpf_v0_11_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.12.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.12.0" FEATURES="bpf_v0_12_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc 0.13.0"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="9" BCC_VERSION="0.13.0" FEATURES="bpf_v0_13_0"
       script:
         - bash build/ci.sh
     - name: "bpf: xenial / nightly / llvm 9 / bcc latest"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="8" BCC_VERSION="latest" FEATURES="bpf"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.8.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.8.0" FEATURES="bpf_v0_8_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.9.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.9.0" FEATURES="bpf_v0_9_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.10.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.10.0" FEATURES="bpf_v0_10_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.11.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.11.0" FEATURES="bpf_v0_11_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.12.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.12.0" FEATURES="bpf_v0_12_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc 0.13.0"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="0.13.0" FEATURES="bpf_v0_13_0"
       script:
         - bash build/ci.sh
     - name: "bpf: bionic / nightly / llvm 10 / bcc latest"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 LLVM_VERSION="10" BCC_VERSION="latest" FEATURES="bpf"
       script:
         - bash build/ci.sh
     - name: "push_kafka: xenial / nightly"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1 FEATURES="push_kafka"
       script:
         - bash build/ci.sh
@@ -197,7 +174,6 @@ matrix:
     - name: "no-default: xenial / nightly"
       os: linux
       dist: xenial
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1
       script:
         - cargo +${TRAVIS_RUST_VERSION} build --no-default-features
@@ -208,7 +184,6 @@ matrix:
     - name: "no-default: bionic / nightly"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1
       script:
         - cargo +${TRAVIS_RUST_VERSION} build --no-default-features
@@ -227,7 +202,6 @@ matrix:
     - name: "clippy"
       os: linux
       dist: bionic
-      rust: nightly-2020-05-01
       env: RUST_BACKTRACE=1
       script:
         - rustup component add clippy --toolchain ${TRAVIS_RUST_VERSION}

--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ The rest of the guide assumes you've chosen to install the toolchain via rustup.
 
 **NOTE:** Rezolus is intended to be built and deployed on Linux systems.
 
-#### Install the nightly toolchain
-```bash
-rustup toolchain install nightly
-```
 #### Clone and build Rezolus from source
 ```bash
 git clone https://github.com/twitter/rezolus

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2020-05-01


### PR DESCRIPTION
Update the rust-toolchain file to specify a nightly version with
a compatible asm syntax. This will remain in-place until the new
syntax is available in a dev build of the stable branch.

Update the readme to remove explicit toolchain version install, its
unnecessary and confusing, the rust-toolchain file addresses this.

Simplify the travis config to reduce the number of places where we
mention the exact nightly version to use.
