### PR TITLE
Feature: Interrupt eBPF sampling

### DIFF
--- a/configs/ci.toml
+++ b/configs/ci.toml
@@ -16,6 +16,7 @@ bpf = true
 enabled = true
 
 [samplers.interrupt]
+bpf = true
 enabled = true
 
 [samplers.memory]

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -41,6 +41,7 @@ bpf = true
 enabled = true
 
 [samplers.interrupt]
+bpf = true
 enabled = true
 
 [samplers.memory]

--- a/src/samplers/interrupt/bpf.c
+++ b/src/samplers/interrupt/bpf.c
@@ -65,7 +65,6 @@ static unsigned int value_to_index2(unsigned int value) {
     return index;
 }
 
-
 // Software IRQ
 int softirq_entry(struct tracepoint__irq__softirq_entry *args)
 {

--- a/src/samplers/interrupt/bpf.c
+++ b/src/samplers/interrupt/bpf.c
@@ -3,7 +3,9 @@
 #include <linux/irqdesc.h>
 #include <linux/interrupt.h>
 
-// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/hardirqs.py
+// This code is taken from: 
+//      https://github.com/iovisor/bcc/blob/master/tools/hardirqs.py
+//      https://github.com/iovisor/bcc/blob/master/tools/softirqs.py
 //
 // Copyright (c) 2015 Brendan Gregg.
 // Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/samplers/interrupt/bpf.c
+++ b/src/samplers/interrupt/bpf.c
@@ -1,0 +1,142 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/irq.h>
+#include <linux/irqdesc.h>
+#include <linux/interrupt.h>
+
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/hardirqs.py
+//
+// Copyright (c) 2015 Brendan Gregg.
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+typedef struct account_val {
+    u64 ts;
+    u32 vec;
+} account_val_t;
+
+// Software IRQ
+BPF_HASH(soft_start, u32, account_val_t);
+BPF_HISTOGRAM(hi, int, 461);
+BPF_HISTOGRAM(timer, int, 461);
+BPF_HISTOGRAM(net_tx, int, 461);
+BPF_HISTOGRAM(net_rx, int, 461);
+BPF_HISTOGRAM(block, int, 461);
+BPF_HISTOGRAM(irq_poll, int, 461);
+BPF_HISTOGRAM(tasklet, int, 461);
+BPF_HISTOGRAM(sched, int, 461);
+BPF_HISTOGRAM(hr_timer, int, 461);
+BPF_HISTOGRAM(rcu, int, 461);
+BPF_HISTOGRAM(unknown, int, 461);
+
+// Hardware IRQ
+BPF_HASH(hard_start, u32, u64);
+BPF_HISTOGRAM(hardirq_total, int, 461);
+
+// histogram indexing
+static unsigned int value_to_index2(unsigned int value) {
+    unsigned int index = 460;
+    if (value < 100) {
+        // 0-99 => [0..100)
+        // 0 => 0
+        // 99 => 99
+        index = value;
+    } else if (value < 1000) {
+        // 100-999 => [100..190)
+        // 100 => 100
+        // 999 => 189
+        index = 90 + value / 10;
+    } else if (value < 10000) {
+        // 1_000-9_999 => [190..280)
+        // 1000 => 190
+        // 9999 => 279
+        index = 180 + value / 100;
+    } else if (value < 100000) {
+        // 10_000-99_999 => [280..370)
+        // 10000 => 280
+        // 99999 => 369
+        index = 270 + value / 1000;
+    } else if (value < 1000000) {
+        // 100_000-999_999 => [370..460)
+        // 100000 => 370
+        // 999999 => 459
+        index = 360 + value / 10000;
+    } else {
+        index = 460;
+    }
+    return index;
+}
+
+
+// Software IRQ
+int softirq_entry(struct tracepoint__irq__softirq_entry *args)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    account_val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.vec = args->vec;
+    soft_start.update(&pid, &val);
+    return 0;
+}
+
+// For bcc 0.7.0 + 
+int softirq_exit(struct tracepoint__irq__softirq_exit *args)
+{
+    u64 delta_us;
+    u32 vec;
+    u32 pid = bpf_get_current_pid_tgid();
+    account_val_t *valp;
+
+    // fetch timestamp and calculate delta
+    valp = soft_start.lookup(&pid);
+    if (valp == 0) {
+        return 0;   // missed start
+    }
+    delta_us = (bpf_ktime_get_ns() - valp->ts) / 1000ul;
+    vec = valp->vec;
+    u64 index = value_to_index2(delta_us);
+
+    // May need updates if more softirqs are added
+    switch (vec) {
+        case 0: hi.increment(index); break;
+        case 1: timer.increment(index); break;
+        case 2: net_tx.increment(index); break;
+        case 3: net_rx.increment(index); break;
+        case 4: block.increment(index); break;
+        case 5: irq_poll.increment(index); break;
+        case 6: tasklet.increment(index); break;
+        case 7: sched.increment(index); break;
+        case 8: hr_timer.increment(index); break;
+        case 9: rcu.increment(index); break;
+        default: unknown.increment(index); break;
+    }
+
+    soft_start.delete(&pid);
+    return 0;
+}
+
+// Hardware IRQ
+int hardirq_entry(struct pt_regs *ctx, struct irq_desc *desc)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    u64 ts = bpf_ktime_get_ns();
+    hard_start.update(&pid, &ts);
+    return 0;
+}
+
+int hardirq_exit(struct pt_regs *ctx)
+{
+    u64 *tsp, delta_us, index;
+    u32 pid = bpf_get_current_pid_tgid();
+
+    // fetch timestamp and calculate delta
+    tsp = hard_start.lookup(&pid);
+    if (tsp == 0 ) {
+        return 0;   // missed start
+    }
+   
+    delta_us = (bpf_ktime_get_ns() - *tsp) / 1000ul;
+    index = value_to_index2(delta_us);
+    hardirq_total.increment(index);
+
+    hard_start.delete(&pid);
+    return 0;
+}

--- a/src/samplers/interrupt/config.rs
+++ b/src/samplers/interrupt/config.rs
@@ -14,6 +14,8 @@ use super::stat::*;
 #[serde(deny_unknown_fields)]
 pub struct InterruptConfig {
     #[serde(default)]
+    bpf: AtomicBool,
+    #[serde(default)]
     enabled: AtomicBool,
     #[serde(default)]
     interval: Option<AtomicUsize>,
@@ -26,6 +28,7 @@ pub struct InterruptConfig {
 impl Default for InterruptConfig {
     fn default() -> Self {
         Self {
+            bpf: Default::default(),
             enabled: Default::default(),
             interval: Default::default(),
             percentiles: default_percentiles(),
@@ -50,6 +53,11 @@ fn default_statistics() -> Vec<InterruptStatistic> {
 
 impl SamplerConfig for InterruptConfig {
     type Statistic = InterruptStatistic;
+
+    fn bpf(&self) -> bool {
+        self.bpf.load(Ordering::Relaxed)
+    }
+
     fn enabled(&self) -> bool {
         self.enabled.load(Ordering::Relaxed)
     }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -125,7 +125,6 @@ impl Interrupt {
     fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
         #[cfg(feature = "bpf")]
         {
-            debug!("Test@@@@@@@ bpf");
             if self.enabled() && self.bpf_enabled() {
                 debug!("initializing bpf");
 

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -3,12 +3,15 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use rustcommon_metrics::*;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
+use crate::common::bpf::*;
 use crate::common::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
@@ -22,6 +25,8 @@ pub use stat::*;
 
 #[allow(dead_code)]
 pub struct Interrupt {
+    bpf: Option<Arc<Mutex<BPF>>>,
+    bpf_last: Arc<Mutex<Instant>>,
     common: Common,
 }
 
@@ -30,7 +35,22 @@ impl Sampler for Interrupt {
     type Statistic = InterruptStatistic;
 
     fn new(common: Common) -> Result<Self, failure::Error> {
-        Ok(Self { common })
+        let fault_tolerant = common.config.general().fault_tolerant();
+
+        #[allow(unused_mut)]
+        let mut sampler = Self {
+            bpf: None,
+            bpf_last: Arc::new(Mutex::new(Instant::now())),
+            common
+        };
+
+        if let Err(e) = sampler.initialize_bpf() {
+            if !fault_tolerant {
+                return Err(e);
+            }
+        }
+        
+        Ok(sampler)
     }
 
     fn spawn(common: Common) {
@@ -73,6 +93,9 @@ impl Sampler for Interrupt {
 
         self.sample_interrupt().await?;
 
+        #[cfg(feature = "bpf")]
+        self.map_result(self.sample_bpf())?;
+
         Ok(())
     }
 
@@ -87,6 +110,44 @@ impl Sampler for Interrupt {
 }
 
 impl Interrupt {
+    #[cfg(feature = "bpf")]
+    fn bpf_enabled(&self) -> bool {
+        if self.sampler_config().bpf() {
+            for statistic in self.sampler_config().statistics() {
+                if statistic.bpf_table().is_some() {
+                    return true
+                }
+            }
+        }
+        false
+    }
+
+    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+        #[cfg(feature = "bpf")]
+        {
+            debug!("Test@@@@@@@ bpf");
+            if self.enabled() && self.bpf_enabled() {
+                debug!("initializing bpf");
+
+                let code  = include_str!("bpf.c");
+                let mut bpf = bcc::core::BPF::new(code)?;
+
+                let hardirq_enter = bpf.load_kprobe("hardirq_entry")?;
+                let hardirq_exit = bpf.load_kprobe("hardirq_exit")?;
+                let softirq_entry = bpf.load_tracepoint("softirq_entry")?;
+                let softirq_exit = bpf.load_tracepoint("softirq_exit")?;
+                bpf.attach_kprobe("handle_irq_event_percpu", hardirq_enter)?;
+                bpf.attach_kretprobe("handle_irq_event_percpu", hardirq_exit)?;
+                bpf.attach_tracepoint("irq", "softirq_entry", softirq_entry)?;
+                bpf.attach_tracepoint("irq", "softirq_exit", softirq_exit)?;
+
+                self.bpf = Some(Arc::new(Mutex::new(BPF {inner: bpf })))
+            }
+        }
+
+        Ok(())
+    }
+
     async fn sample_interrupt(&self) -> Result<(), std::io::Error> {
         let file = File::open("/proc/interrupts").await?;
         let reader = BufReader::new(file);
@@ -208,6 +269,34 @@ impl Interrupt {
             }
         }
 
+        Ok(())
+    }
+
+    #[cfg(feature = "bpf")]
+    fn sample_bpf(&self) -> Result<(), std::io::Error> {
+        if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
+            if let Some(ref bpf) = self.bpf {
+                let bpf = bpf.lock().unwrap();
+                let time = time::precise_time_ns();
+                for statistic in self.sampler_config().statistics() {
+                    if let Some(table) = statistic.bpf_table() {
+                        let mut table = (*bpf).inner.table(table);
+
+                        for (&value, &count) in &map_from_table(&mut table) {
+                            if count > 0 {
+                                self.metrics().record_distribution(
+                                    statistic,
+                                    time,
+                                    value * 1000,
+                                    count,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            *self.bpf_last.lock().unwrap() = Instant::now();
+        }
         Ok(())
     }
 }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -41,7 +41,7 @@ impl Sampler for Interrupt {
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
-            common
+            common,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
@@ -49,7 +49,7 @@ impl Sampler for Interrupt {
                 return Err(e);
             }
         }
-        
+
         Ok(sampler)
     }
 
@@ -115,7 +115,7 @@ impl Interrupt {
         if self.sampler_config().bpf() {
             for statistic in self.sampler_config().statistics() {
                 if statistic.bpf_table().is_some() {
-                    return true
+                    return true;
                 }
             }
         }
@@ -128,7 +128,7 @@ impl Interrupt {
             if self.enabled() && self.bpf_enabled() {
                 debug!("initializing bpf");
 
-                let code  = include_str!("bpf.c");
+                let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 let hardirq_enter = bpf.load_kprobe("hardirq_entry")?;
@@ -140,7 +140,7 @@ impl Interrupt {
                 bpf.attach_tracepoint("irq", "softirq_entry", softirq_entry)?;
                 bpf.attach_tracepoint("irq", "softirq_exit", softirq_exit)?;
 
-                self.bpf = Some(Arc::new(Mutex::new(BPF {inner: bpf })))
+                self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))
             }
         }
 

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -273,28 +273,33 @@ impl Interrupt {
 
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
-        if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
-            if let Some(ref bpf) = self.bpf {
-                let bpf = bpf.lock().unwrap();
-                let time = time::precise_time_ns();
-                for statistic in self.sampler_config().statistics() {
-                    if let Some(table) = statistic.bpf_table() {
-                        let mut table = (*bpf).inner.table(table);
+        use crate::common::MICROSECOND;
 
-                        for (&value, &count) in &map_from_table(&mut table) {
-                            if count > 0 {
-                                self.metrics().record_distribution(
-                                    statistic,
-                                    time,
-                                    value * 1000,
-                                    count,
-                                );
+        // Sample bpf
+        {
+            if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
+                if let Some(ref bpf) = self.bpf {
+                    let bpf = bpf.lock().unwrap();
+                    let time = time::precise_time_ns();
+                    for statistic in self.sampler_config().statistics() {
+                        if let Some(table) = statistic.bpf_table() {
+                            let mut table = (*bpf).inner.table(table);
+
+                            for (&value, &count) in &map_from_table(&mut table) {
+                                if count > 0 {
+                                    self.metrics().record_distribution(
+                                        statistic,
+                                        time,
+                                        value * MICROSECOND,
+                                        count,
+                                    );
+                                }
                             }
                         }
                     }
                 }
+                *self.bpf_last.lock().unwrap() = Instant::now();
             }
-            *self.bpf_last.lock().unwrap() = Instant::now();
         }
         Ok(())
     }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -274,7 +274,7 @@ impl Interrupt {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         use crate::common::MICROSECOND;
-        
+
         if self.bpf_last.lock().unwrap().elapsed() >= self.general_config().window() {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();

--- a/src/samplers/interrupt/stat.rs
+++ b/src/samplers/interrupt/stat.rs
@@ -69,6 +69,50 @@ pub enum InterruptStatistic {
     Node0Nvme,
     #[strum(serialize = "interrupt/node1/nvme")]
     Node1Nvme,
+    #[strum(serialize = "interrupt/softirq/hi")]
+    SoftIrqHI,
+    #[strum(serialize = "interrupt/softirq/timer")]
+    SoftIrqTimer,
+    #[strum(serialize = "interrupt/softirq/net_rx")]
+    SoftIrqNetRx,
+    #[strum(serialize = "interrupt/softirq/net_tx")]
+    SoftIrqNetTx,
+    #[strum(serialize = "interrupt/softirq/block")]
+    SoftIrqBlock,
+    #[strum(serialize = "interrupt/softirq/irq_poll")]
+    SoftIrqPoll,
+    #[strum(serialize = "interrupt/softirq/tasklet")]
+    SoftIrqTasklet,
+    #[strum(serialize = "interrupt/softirq/sched")]
+    SoftIrqSched,
+    #[strum(serialize = "interrupt/softirq/hr_timer")]
+    SoftIrqHRTimer,
+    #[strum(serialize = "interrupt/softirq/rcu")]
+    SoftIrqRCU,
+    #[strum(serialize = "interrupt/softirq/unknown")]
+    SoftIrqUnknown,
+    #[strum(serialize = "interrupt/hardirq")]
+    HardIrq,
+}
+
+impl InterruptStatistic {
+    pub fn bpf_table(self) -> Option<&'static str> {
+        match self {
+            Self::SoftIrqHI => Some("hi"),
+            Self::SoftIrqTimer => Some("timer"),
+            Self::SoftIrqNetRx => Some("net_rx"),
+            Self::SoftIrqNetTx => Some("net_tx"),
+            Self::SoftIrqBlock => Some("block"),
+            Self::SoftIrqPoll => Some("irq_poll"),
+            Self::SoftIrqTasklet => Some("tasklet"),
+            Self::SoftIrqSched => Some("sched"),
+            Self::SoftIrqHRTimer => Some("hr_timer"),
+            Self::SoftIrqRCU => Some("rcu"),
+            Self::SoftIrqUnknown => Some("unknown"),
+            Self::HardIrq => Some("hardirq_total"),
+            _ => None,
+        }
+    }
 }
 
 impl TryFrom<&str> for InterruptStatistic {
@@ -85,6 +129,10 @@ impl Statistic for InterruptStatistic {
     }
 
     fn source(&self) -> Source {
-        Source::Counter
+        if self.bpf_table().is_some() {
+            Source::Distribution
+        } else {
+            Source::Counter
+        }
     }
 }


### PR DESCRIPTION
Adds interrupt eBPF traces.

Changed:
`samplers/interrupt`

Consideration:
 - Hardware interrupts are all grouped together and only produce a single distribution.
 - May also need to modify other `.toml` files to enable bpf on interrupts