### PR TITLE
add cargo-audit to ci

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -171,3 +171,12 @@ jobs:
       run: rustup component add clippy
     - name: clippy
       run: cargo clippy || cargo clippy
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install
+      run: cargo install cargo-audit
+    - name: audit
+      run: cargo audit


### PR DESCRIPTION
Adds cargo-audit to ci to check for any open rustsec advisories
