### PR TITLE
Modify bpf instantiation to use builder pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "High resolution systems performance telemetry agent"
 
 [dependencies]
 async-trait = "0.1.23"
-bcc = { version = "0.0.21", optional = true }
+bcc = { version = "0.0.22", optional = true }
 clap = "2.33.0"
 ctrlc = { version = "3.1.3", features = ["termination"] }
 dashmap = "3.11.7"

--- a/src/common/bpf.rs
+++ b/src/common/bpf.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "bpf")]
 pub struct BPF {
-    pub inner: bcc::core::BPF,
+    pub inner: bcc::BPF,
 }
 
 #[cfg(not(feature = "bpf"))]

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -142,19 +142,19 @@ impl Disk {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
                 // load + attach kprobes!
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_pid_start")
                     .function("blk_account_io_start")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_req_start")
                     .function("blk_start_request")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_req_start")
                     .function("blk_mq_start_request")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("do_count")
                     .function("blk_account_io_completion")
                     .attach(&mut bpf)?;

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -142,19 +142,19 @@ impl Disk {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
                 // load + attach kprobes!
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_pid_start")
                     .function("blk_account_io_start")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_req_start")
                     .function("blk_start_request")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_req_start")
                     .function("blk_mq_start_request")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("do_count")
                     .function("blk_account_io_completion")
                     .attach(&mut bpf)?;

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -140,7 +140,7 @@ impl Disk {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
                 // load + attach kprobes!
                 bcc::Kprobe::new()
                     .name("trace_pid_start")

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -142,15 +142,23 @@ impl Disk {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
                 // load + attach kprobes!
-                let trace_pid_start = bpf.load_kprobe("trace_pid_start")?;
-                let trace_req_start = bpf.load_kprobe("trace_req_start")?;
-                let trace_mq_req_start = bpf.load_kprobe("trace_req_start")?;
-                let do_count = bpf.load_kprobe("do_count")?;
+                bcc::core::Kprobe::new()
+                    .name("trace_pid_start")
+                    .function("blk_account_io_start")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_req_start")
+                    .function("blk_start_request")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_req_start")
+                    .function("blk_mq_start_request")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("do_count")
+                    .function("blk_account_io_completion")
+                    .attach(&mut bpf)?;
 
-                bpf.attach_kprobe("blk_account_io_start", trace_pid_start)?;
-                bpf.attach_kprobe("blk_start_request", trace_req_start)?;
-                bpf.attach_kprobe("blk_mq_start_request", trace_mq_req_start)?;
-                bpf.attach_kprobe("blk_account_io_completion", do_count)?;
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -143,19 +143,19 @@ impl Disk {
                 let mut bpf = bcc::BPF::new(code)?;
                 // load + attach kprobes!
                 bcc::Kprobe::new()
-                    .name("trace_pid_start")
+                    .handler("trace_pid_start")
                     .function("blk_account_io_start")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_req_start")
+                    .handler("trace_req_start")
                     .function("blk_start_request")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_req_start")
+                    .handler("trace_req_start")
                     .function("blk_mq_start_request")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("do_count")
+                    .handler("do_count")
                     .function("blk_account_io_completion")
                     .attach(&mut bpf)?;
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -146,19 +146,19 @@ impl Ext4 {
                     .handler("trace_entry")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
-                bcc::Kprobe::new()
+                bcc::Kretprobe::new()
                     .handler("trace_read_return")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::Kprobe::new()
+                bcc::Kretprobe::new()
                     .handler("trace_write_return")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::Kprobe::new()
+                bcc::Kretprobe::new()
                     .handler("trace_open_return")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
-                bcc::Kprobe::new()
+                bcc::Kretprobe::new()
                     .handler("trace_fsync_return")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -130,35 +130,35 @@ impl Ext4 {
                 let mut bpf = bcc::core::BPF::new(&code)?;
 
                 // load + attach kprobes!
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_read_entry")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_read_return")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_write_return")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_open_return")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_fsync_return")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -130,39 +130,39 @@ impl Ext4 {
                 let mut bpf = bcc::core::BPF::new(&code)?;
 
                 // load + attach kprobes!
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_read_entry")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_read_return")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_write_return")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_open_return")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_fsync_return")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
-                    
+
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -131,35 +131,35 @@ impl Ext4 {
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()
-                    .name("trace_read_entry")
+                    .handler("trace_read_entry")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_read_return")
+                    .handler("trace_read_return")
                     .function("generic_file_read_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_write_return")
+                    .handler("trace_write_return")
                     .function("ext4_file_write_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_open_return")
+                    .handler("trace_open_return")
                     .function("ext4_file_open")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_fsync_return")
+                    .handler("trace_fsync_return")
                     .function("ext4_sync_file")
                     .attach(&mut bpf)?;
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -127,7 +127,7 @@ impl Ext4 {
                 let addr = "0x".to_string()
                     + &crate::common::bpf::symbol_lookup("ext4_file_operations").unwrap();
                 let code = code.replace("EXT4_FILE_OPERATIONS", &addr);
-                let mut bpf = bcc::core::BPF::new(&code)?;
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -130,24 +130,39 @@ impl Ext4 {
                 let mut bpf = bcc::core::BPF::new(&code)?;
 
                 // load + attach kprobes!
-                let generic_file_read_iter_entry = bpf.load_kprobe("trace_read_entry")?;
-                let ext4_file_write_iter_entry = bpf.load_kprobe("trace_entry")?;
-                let ext4_file_open_entry = bpf.load_kprobe("trace_entry")?;
-                let ext4_sync_file_entry = bpf.load_kprobe("trace_entry")?;
-                let generic_file_read_iter_return = bpf.load_kprobe("trace_read_return")?;
-                let ext4_file_write_iter_return = bpf.load_kprobe("trace_write_return")?;
-                let ext4_file_open_return = bpf.load_kprobe("trace_open_return")?;
-                let ext4_sync_file_return = bpf.load_kprobe("trace_fsync_return")?;
-
-                bpf.attach_kprobe("generic_file_read_iter", generic_file_read_iter_entry)?;
-                bpf.attach_kprobe("ext4_file_write_iter", ext4_file_write_iter_entry)?;
-                bpf.attach_kprobe("ext4_file_open", ext4_file_open_entry)?;
-                bpf.attach_kprobe("ext4_sync_file", ext4_sync_file_entry)?;
-                bpf.attach_kretprobe("generic_file_read_iter", generic_file_read_iter_return)?;
-                bpf.attach_kretprobe("ext4_file_write_iter", ext4_file_write_iter_return)?;
-                bpf.attach_kretprobe("ext4_file_open", ext4_file_open_return)?;
-                bpf.attach_kretprobe("ext4_sync_file", ext4_sync_file_return)?;
-
+                bcc::core::Kprobe::new()
+                    .name("trace_read_entry")
+                    .function("generic_file_read_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("ext4_file_write_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("ext4_file_open")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("ext4_sync_file")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_read_return")
+                    .function("generic_file_read_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_write_return")
+                    .function("ext4_file_write_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_open_return")
+                    .function("ext4_file_open")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_fsync_return")
+                    .function("ext4_sync_file")
+                    .attach(&mut bpf)?;
+                    
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -130,15 +130,25 @@ impl Interrupt {
 
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
-
-                let hardirq_enter = bpf.load_kprobe("hardirq_entry")?;
-                let hardirq_exit = bpf.load_kprobe("hardirq_exit")?;
-                let softirq_entry = bpf.load_tracepoint("softirq_entry")?;
-                let softirq_exit = bpf.load_tracepoint("softirq_exit")?;
-                bpf.attach_kprobe("handle_irq_event_percpu", hardirq_enter)?;
-                bpf.attach_kretprobe("handle_irq_event_percpu", hardirq_exit)?;
-                bpf.attach_tracepoint("irq", "softirq_entry", softirq_entry)?;
-                bpf.attach_tracepoint("irq", "softirq_exit", softirq_exit)?;
+                
+                bcc::core::Kprobe::new()
+                    .name("hardirq_entry")
+                    .function("handle_irq_event_percpu")
+                    .attach(&mut bpf)?;
+                bcc::core::Kretprobe::new()
+                    .name("hardirq_exit")
+                    .function("handle_irq_event_percpu")
+                    .attach(&mut bpf)?;
+                bcc::core::Tracepoint::new()
+                    .name("softirq_entry")
+                    .subsystem("irq")
+                    .tracepoint("softirq_entry")
+                    .attach(&mut bpf)?;
+                bcc::core::Tracepoint::new()
+                    .name("softirq_exit")
+                    .subsystem("irq")
+                    .tracepoint("softirq_exit")
+                    .attach(&mut bpf)?;
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))
             }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -131,7 +131,7 @@ impl Interrupt {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                bcc::core::::kprobe::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("hardirq_entry")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -135,7 +135,7 @@ impl Interrupt {
                     .name("hardirq_entry")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
-                bcc::core::::kprobe::Kretprobe::new()
+                bcc::core::kprobe::Kretprobe::new()
                     .name("hardirq_exit")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -131,20 +131,20 @@ impl Interrupt {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                bcc::core::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("hardirq_entry")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kretprobe::new()
+                bcc::Kretprobe::new()
                     .name("hardirq_exit")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
-                bcc::core::tracepoint::Tracepoint::new()
+                bcc::Tracepoint::new()
                     .name("softirq_entry")
                     .subsystem("irq")
                     .tracepoint("softirq_entry")
                     .attach(&mut bpf)?;
-                bcc::core::tracepoint::Tracepoint::new()
+                bcc::Tracepoint::new()
                     .name("softirq_exit")
                     .subsystem("irq")
                     .tracepoint("softirq_exit")

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -129,7 +129,7 @@ impl Interrupt {
                 debug!("initializing bpf");
 
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
 
                 bcc::Kprobe::new()
                     .name("hardirq_entry")

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -130,21 +130,21 @@ impl Interrupt {
 
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
-                
-                bcc::core::Kprobe::new()
+
+                bcc::core::::kprobe::Kprobe::new()
                     .name("hardirq_entry")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
-                bcc::core::Kretprobe::new()
+                bcc::core::::kprobe::Kretprobe::new()
                     .name("hardirq_exit")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
-                bcc::core::Tracepoint::new()
+                bcc::core::tracepoint::Tracepoint::new()
                     .name("softirq_entry")
                     .subsystem("irq")
                     .tracepoint("softirq_entry")
                     .attach(&mut bpf)?;
-                bcc::core::Tracepoint::new()
+                bcc::core::tracepoint::Tracepoint::new()
                     .name("softirq_exit")
                     .subsystem("irq")
                     .tracepoint("softirq_exit")

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -132,20 +132,20 @@ impl Interrupt {
                 let mut bpf = bcc::BPF::new(code)?;
 
                 bcc::Kprobe::new()
-                    .name("hardirq_entry")
+                    .handler("hardirq_entry")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
                 bcc::Kretprobe::new()
-                    .name("hardirq_exit")
+                    .handler("hardirq_exit")
                     .function("handle_irq_event_percpu")
                     .attach(&mut bpf)?;
                 bcc::Tracepoint::new()
-                    .name("softirq_entry")
+                    .handler("softirq_entry")
                     .subsystem("irq")
                     .tracepoint("softirq_entry")
                     .attach(&mut bpf)?;
                 bcc::Tracepoint::new()
-                    .name("softirq_exit")
+                    .handler("softirq_exit")
                     .subsystem("irq")
                     .tracepoint("softirq_exit")
                     .attach(&mut bpf)?;

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -143,12 +143,12 @@ impl Network {
                 let mut bpf = bcc::BPF::new(code)?;
 
                 bcc::Tracepoint::new()
-                    .name("trace_transmit")
+                    .handler("trace_transmit")
                     .subsystem("net")
                     .tracepoint("net_dev_queue")
                     .attach(&mut bpf)?;
                 bcc::Tracepoint::new()
-                    .name("trace_receive")
+                    .handler("trace_receive")
                     .subsystem("net")
                     .tracepoint("netif_rx")
                     .attach(&mut bpf)?;

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -140,7 +140,7 @@ impl Network {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
 
                 bcc::Tracepoint::new()
                     .name("trace_transmit")

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -142,12 +142,12 @@ impl Network {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                bcc::tracepoint::Tracepoint::new()
+                bcc::Tracepoint::new()
                     .name("trace_transmit")
                     .subsystem("net")
                     .tracepoint("net_dev_queue")
                     .attach(&mut bpf)?;
-                bcc::tracepoint::Tracepoint::new()
+                bcc::Tracepoint::new()
                     .name("trace_receive")
                     .subsystem("net")
                     .tracepoint("netif_rx")

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -142,12 +142,12 @@ impl Network {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                bcc::core::Tracepoint::new()
+                bcc::core::tracepoint::Tracepoint::new()
                     .name("trace_transmit")
                     .subsystem("net")
                     .tracepoint("net_dev_queue")
                     .attach(&mut bpf)?;
-                bcc::core::Tracepoint::new()
+                bcc::core::tracepoint::Tracepoint::new()
                     .name("trace_receive")
                     .subsystem("net")
                     .tracepoint("netif_rx")

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -142,11 +142,16 @@ impl Network {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                // load + attach kprobes!
-                let trace_transmit = bpf.load_tracepoint("trace_transmit")?;
-                bpf.attach_tracepoint("net", "net_dev_queue", trace_transmit)?;
-                let trace_receive = bpf.load_tracepoint("trace_receive")?;
-                bpf.attach_tracepoint("net", "netif_rx", trace_receive)?;
+                bcc::core::Tracepoint::new()
+                    .name("trace_transmit")
+                    .subsystem("net")
+                    .tracepoint("net_dev_queue")
+                    .attach(&mut bpf)?;
+                bcc::core::Tracepoint::new()
+                    .name("trace_receive")
+                    .subsystem("net")
+                    .tracepoint("netif_rx")
+                    .attach(&mut bpf)?;
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -142,12 +142,12 @@ impl Network {
                 let code = include_str!("bpf.c");
                 let mut bpf = bcc::core::BPF::new(code)?;
 
-                bcc::core::tracepoint::Tracepoint::new()
+                bcc::tracepoint::Tracepoint::new()
                     .name("trace_transmit")
                     .subsystem("net")
                     .tracepoint("net_dev_queue")
                     .attach(&mut bpf)?;
-                bcc::core::tracepoint::Tracepoint::new()
+                bcc::tracepoint::Tracepoint::new()
                     .name("trace_receive")
                     .subsystem("net")
                     .tracepoint("netif_rx")

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -286,15 +286,15 @@ impl Scheduler {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_run")
                     .function("finish_task_switch")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_ttwu_do_wakeup")
                     .function("ttwu_do_wakeup")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_wake_up_new_task")
                     .function("wake_up_new_task")
                     .attach(&mut bpf)?;

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -286,14 +286,19 @@ impl Scheduler {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                let trace_run = bpf.load_kprobe("trace_run")?;
-                let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup")?;
-                let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task")?;
-
-                bpf.attach_kprobe("finish_task_switch", trace_run)?;
-                bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)?;
-                bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)?;
-
+                bcc::core::Kprobe::new()
+                    .name("trace_run")
+                    .function("finish_task_switch")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_ttwu_do_wakeup")
+                    .function("ttwu_do_wakeup")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_wake_up_new_task")
+                    .function("wake_up_new_task")
+                    .attach(&mut bpf)?;
+                    
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -286,19 +286,19 @@ impl Scheduler {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_run")
                     .function("finish_task_switch")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_ttwu_do_wakeup")
                     .function("ttwu_do_wakeup")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_wake_up_new_task")
                     .function("wake_up_new_task")
                     .attach(&mut bpf)?;
-                    
+
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -283,7 +283,7 @@ impl Scheduler {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -286,15 +286,15 @@ impl Scheduler {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_run")
                     .function("finish_task_switch")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_ttwu_do_wakeup")
                     .function("ttwu_do_wakeup")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_wake_up_new_task")
                     .function("wake_up_new_task")
                     .attach(&mut bpf)?;

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -287,15 +287,15 @@ impl Scheduler {
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()
-                    .name("trace_run")
+                    .handler("trace_run")
                     .function("finish_task_switch")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_ttwu_do_wakeup")
+                    .handler("trace_ttwu_do_wakeup")
                     .function("ttwu_do_wakeup")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_wake_up_new_task")
+                    .handler("trace_wake_up_new_task")
                     .function("wake_up_new_task")
                     .attach(&mut bpf)?;
 

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -140,15 +140,15 @@ impl Tcp {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v4_connect")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v6_connect")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_tcp_rcv_state_process")
                     .function("tcp_rcv_state_process")
                     .attach(&mut bpf)?;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -137,7 +137,7 @@ impl Tcp {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc:BPF::new(code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -140,15 +140,15 @@ impl Tcp {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v4_connect")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v6_connect")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_tcp_rcv_state_process")
                     .function("tcp_rcv_state_process")
                     .attach(&mut bpf)?;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -140,15 +140,15 @@ impl Tcp {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v4_connect")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_connect")
                     .function("tcp_v6_connect")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_tcp_rcv_state_process")
                     .function("tcp_rcv_state_process")
                     .attach(&mut bpf)?;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -137,7 +137,7 @@ impl Tcp {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc:BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -141,15 +141,15 @@ impl Tcp {
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()
-                    .name("trace_connect")
+                    .handler("trace_connect")
                     .function("tcp_v4_connect")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_connect")
+                    .handler("trace_connect")
                     .function("tcp_v6_connect")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_tcp_rcv_state_process")
+                    .handler("trace_tcp_rcv_state_process")
                     .function("tcp_rcv_state_process")
                     .attach(&mut bpf)?;
 

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -140,12 +140,18 @@ impl Tcp {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                let tcp_v4_connect = bpf.load_kprobe("trace_connect")?;
-                let tcp_v6_connect = bpf.load_kprobe("trace_connect")?;
-                let tcp_rcv_state_process = bpf.load_kprobe("trace_tcp_rcv_state_process")?;
-                bpf.attach_kprobe("tcp_v4_connect", tcp_v4_connect)?;
-                bpf.attach_kprobe("tcp_v6_connect", tcp_v6_connect)?;
-                bpf.attach_kprobe("tcp_rcv_state_process", tcp_rcv_state_process)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_connect")
+                    .function("tcp_v4_connect")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_connect")
+                    .function("tcp_v6_connect")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_tcp_rcv_state_process")
+                    .function("tcp_rcv_state_process")
+                    .attach(&mut bpf)?;
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))
             }

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -128,24 +128,38 @@ impl Xfs {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                let read_entry = bpf.load_kprobe("trace_entry")?;
-                let write_entry = bpf.load_kprobe("trace_entry")?;
-                let open_entry = bpf.load_kprobe("trace_entry")?;
-                let fsync_entry = bpf.load_kprobe("trace_entry")?;
-                let read_return = bpf.load_kprobe("trace_read_return")?;
-                let write_return = bpf.load_kprobe("trace_write_return")?;
-                let open_return = bpf.load_kprobe("trace_open_return")?;
-                let fsync_return = bpf.load_kprobe("trace_fsync_return")?;
-
-                bpf.attach_kprobe("xfs_file_read_iter", read_entry)?;
-                bpf.attach_kprobe("xfs_file_write_iter", write_entry)?;
-                bpf.attach_kprobe("xfs_file_open", open_entry)?;
-                bpf.attach_kprobe("xfs_file_fsync", fsync_entry)?;
-                bpf.attach_kretprobe("xfs_file_read_iter", read_return)?;
-                bpf.attach_kretprobe("xfs_file_write_iter", write_return)?;
-                bpf.attach_kretprobe("xfs_file_open", open_return)?;
-                bpf.attach_kretprobe("xfs_file_fsync", fsync_return)?;
-
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("xfs_file_read_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("xfs_file_write_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("xfs_file_open")
+                    .attach(&mut bpf)?;
+                bcc::core::Kprobe::new()
+                    .name("trace_entry")
+                    .function("xfs_file_fsync")
+                    .attach(&mut bpf)?;
+                bcc::core::Kretprobe::new()
+                    .name("trace_read_return")
+                    .function("xfs_file_read_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kretprobe::new()
+                    .name("trace_write_return")
+                    .function("xfs_file_write_iter")
+                    .attach(&mut bpf)?;
+                bcc::core::Kretprobe::new()
+                    .name("trace_open_return")
+                    .function("xfs_file_open")
+                    .attach(&mut bpf)?;
+                bcc::core::Kretprobe::new()
+                    .name("trace_fsync_return")
+                    .function("xfs_file_fsync")
+                    .attach(&mut bpf)?;
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
             }
         }

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -128,35 +128,35 @@ impl Xfs {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::Kprobe::new()
+                bcc::core::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;
-                bcc::core::Kretprobe::new()
+                bcc::core::kprobe::Kretprobe::new()
                     .name("trace_read_return")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kretprobe::new()
+                bcc::core::kprobe::Kretprobe::new()
                     .name("trace_write_return")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::Kretprobe::new()
+                bcc::core::kprobe::Kretprobe::new()
                     .name("trace_open_return")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::Kretprobe::new()
+                bcc::core::kprobe::Kretprobe::new()
                     .name("trace_fsync_return")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -125,7 +125,7 @@ impl Xfs {
 
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::core::BPF::new(code)?;
+                let mut bpf = bcc::BPF::new(code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -128,35 +128,35 @@ impl Xfs {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kprobe::new()
+                bcc::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kretprobe::new()
+                bcc::Kretprobe::new()
                     .name("trace_read_return")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kretprobe::new()
+                bcc::Kretprobe::new()
                     .name("trace_write_return")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kretprobe::new()
+                bcc::Kretprobe::new()
                     .name("trace_open_return")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::kprobe::Kretprobe::new()
+                bcc::Kretprobe::new()
                     .name("trace_fsync_return")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -128,35 +128,35 @@ impl Xfs {
                 let mut bpf = bcc::core::BPF::new(code)?;
 
                 // load + attach kprobes!
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kprobe::new()
+                bcc::kprobe::Kprobe::new()
                     .name("trace_entry")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kretprobe::new()
+                bcc::kprobe::Kretprobe::new()
                     .name("trace_read_return")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kretprobe::new()
+                bcc::kprobe::Kretprobe::new()
                     .name("trace_write_return")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kretprobe::new()
+                bcc::kprobe::Kretprobe::new()
                     .name("trace_open_return")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
-                bcc::core::kprobe::Kretprobe::new()
+                bcc::kprobe::Kretprobe::new()
                     .name("trace_fsync_return")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -129,35 +129,35 @@ impl Xfs {
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
-                    .name("trace_entry")
+                    .handler("trace_entry")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;
                 bcc::Kretprobe::new()
-                    .name("trace_read_return")
+                    .handler("trace_read_return")
                     .function("xfs_file_read_iter")
                     .attach(&mut bpf)?;
                 bcc::Kretprobe::new()
-                    .name("trace_write_return")
+                    .handler("trace_write_return")
                     .function("xfs_file_write_iter")
                     .attach(&mut bpf)?;
                 bcc::Kretprobe::new()
-                    .name("trace_open_return")
+                    .handler("trace_open_return")
                     .function("xfs_file_open")
                     .attach(&mut bpf)?;
                 bcc::Kretprobe::new()
-                    .name("trace_fsync_return")
+                    .handler("trace_fsync_return")
                     .function("xfs_file_fsync")
                     .attach(&mut bpf)?;
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));


### PR DESCRIPTION
Changes bpf initialization function to use the new builder pattern.

#### I did not change the bcc version in `Cargo.toml` yet in case there are new changes