### PR TITLE
fix: statistic registration

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -141,5 +141,11 @@ else
     cargo test --release
 fi
 
-sudo timeout --signal 15 --preserve-status 5.0m target/release/rezolus --config configs/example.toml
-sudo timeout --signal 15 --preserve-status 5.0m target/release/rezolus --config configs/ci.toml
+sudo timeout --signal 15 --preserve-status 5.0m target/release/rezolus --config configs/example.toml &
+sleep 180
+curl -s http://localhost:4242/vars
+sleep 180
+sudo timeout --signal 15 --preserve-status 5.0m target/release/rezolus --config configs/ci.toml &
+sleep 180
+curl -s http://localhost:4242/vars
+sleep 180

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -92,11 +92,11 @@ pub trait Sampler: Sized + Send {
                 .register(statistic, self.summary(statistic));
             self.common()
                 .metrics()
-                .delete_output(statistic, Output::Reading);
+                .add_output(statistic, Output::Reading);
             for percentile in self.sampler_config().percentiles() {
                 self.common()
                     .metrics()
-                    .delete_output(statistic, Output::Percentile(*percentile));
+                    .add_output(statistic, Output::Percentile(*percentile));
             }
         }
     }


### PR DESCRIPTION
The `Sampler::register()` default impl is calling `delete_output()`
when it should call `add_output()`. Does not appear to effect the
actual output, but seems incorrect for `register`.

Changes the method used in registration and adds a curl command to
the workflow so we can see the metrics exposition endpoint in ci.
