### PR TITLE
fix: use latest bcc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bcc"
-version = "0.0.22"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2923c9e1f1039b9758691180d3655c532c83a2df90f142958e33847309d1de3b"
+checksum = "acc1c1b2937ca3db6cf04034371232eac959b5b7e0acdaa1e4cd81c2d1b099c7"
 dependencies = [
  "bcc-sys",
  "byteorder 1.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "High resolution systems performance telemetry agent"
 
 [dependencies]
 async-trait = "0.1.23"
-bcc = { version = "0.0.22", optional = true }
+bcc = { version = "0.0.23", optional = true }
 clap = "2.33.0"
 ctrlc = { version = "3.1.3", features = ["termination"] }
 dashmap = "3.11.7"


### PR DESCRIPTION
Latest bcc crate has fixes around reading the data back into
userspace where the first entry might incorrectly have a zero value
instead of the expected value. While unlikely to dramatically
effect the existing BPF telemetry, this is a correctness fix.
