### PR TITLE
set max_threads and thread name for tokio runtime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .threaded_scheduler()
         .enable_time()
         .core_threads(config.general().threads())
+        .max_threads(config.general().threads() * 2) // extra threads for block_on
+        .thread_name("rezolus-worker")
         .build()
         .unwrap();
 


### PR DESCRIPTION
Set the max_threads to 2x core_threads to allow for block_on but
still place a cap on maximum threads. Sets the thread name to match
the process better.
