### PR TITLE
fix: memcache sampler not initialized

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -161,7 +161,7 @@ jobs:
     env:
       BCC: "0.15.0"
       DIST: focal
-      FEATURES: bpf_v0_15_0 bpf_static
+      FEATURES: bpf_v0_15_0
       LLVM: 9
     services:
       memcached:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -155,6 +155,20 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run CI
       run: bash -e build/ci.sh
+  memcache-smoketest:
+    name: memcache smoketest
+    runs-on: ubuntu-18.04
+    services:
+      memcached:
+        image: memcached
+        ports:
+          - 11211:11211
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: bash build/ci.sh
+      - name: Smoketest
+        run: target/release/rezolus --config configs/memcache.toml & sleep 180; curl -s http://localhost:4242/vars
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -157,7 +157,12 @@ jobs:
       run: bash -e build/ci.sh
   memcache-smoketest:
     name: memcache smoketest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    env:
+      BCC: "0.15.0"
+      DIST: focal
+      FEATURES: bpf_v0_15_0 bpf_static
+      LLVM: 9
     services:
       memcached:
         image: memcached

--- a/configs/memcache.toml
+++ b/configs/memcache.toml
@@ -6,6 +6,7 @@
 [general]
 listen = "0.0.0.0:4242"
 fault_tolerant = false
+reading_suffix = ""
 
 [samplers]
 [samplers.memcache]

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ext4::spawn(common.clone());
     Http::spawn(common.clone());
     Interrupt::spawn(common.clone());
+    Memcache::spawn(common.clone());
     Memory::spawn(common.clone());
     Network::spawn(common.clone());
     Rezolus::spawn(common.clone());

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -51,6 +51,13 @@ impl Sampler for Memcache {
     type Statistic = MemcacheStatistic;
 
     fn new(common: Common) -> Result<Self, failure::Error> {
+        if !common.config.samplers().memcache().enabled() {
+            return Ok(Self {
+                address: "localhost:11211".to_socket_addrs().unwrap().next().unwrap(),
+                common,
+                stream: None,
+            });
+        }
         if common.config.samplers().memcache().endpoint().is_none() {
             return Err(format_err!("no memcache endpoint configured"));
         }

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -73,7 +73,6 @@ impl Sampler for Memcache {
             common,
             stream: None,
         };
-        ret.reconnect();
         Ok(ret)
     }
 

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -33,6 +33,7 @@ pub use disk::Disk;
 pub use ext4::Ext4;
 pub use http::Http;
 pub use interrupt::Interrupt;
+pub use memcache::Memcache;
 pub use memory::Memory;
 pub use network::Network;
 pub use rezolus::Rezolus;


### PR DESCRIPTION
Problem

The memcache sampler isn't actually initialized at startup. This
means that even a proper memcache configuration won't produce
stats.

Solution

Initialize the memcache sampler, update its config, and add a
smoketest to ci.

Result

Stats for memcache work again.