### PR TITLE
fix memcache sampler panic

### DIFF
--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -53,7 +53,9 @@ impl Sampler for Cpu {
             tick_duration: nanos_per_tick(),
         };
 
-        sampler.register();
+        if sampler.sampler_config().enabled() {
+            sampler.register();
+        }
 
         // we initialize perf last so we can delay
         if sampler.sampler_config().enabled() && sampler.sampler_config().perf_events() {

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -7,8 +7,6 @@ use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 
 use async_trait::async_trait;
 use rustcommon_metrics::*;
-// use tokio::io::{AsyncReadExt, AsyncWriteExt};
-// use tokio::net::TcpStream;
 
 use crate::config::*;
 use crate::samplers::Common;

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -144,8 +144,6 @@ impl Sampler for Memcache {
                                                 Output::Percentile(*percentile),
                                             );
                                         }
-                                    } else {
-                                        warn!("could not parse: {} {}", *name, value);
                                     }
                                 }
                                 _ => {
@@ -161,8 +159,6 @@ impl Sampler for Memcache {
                                         self.common()
                                             .metrics()
                                             .record_gauge(&statistic, time, value);
-                                    } else {
-                                        warn!("could not parse: {} {}", *name, value);
                                     }
                                 }
                             }

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 
 use async_trait::async_trait;
 use rustcommon_metrics::*;
@@ -92,7 +92,6 @@ impl Sampler for Memcache {
         }
 
         if let Some(ref mut stream) = self.stream {
-
             if stream.write_all(b"stats\r\n").is_ok() {
                 let mut buffer = [0_u8; 16355];
                 loop {
@@ -133,7 +132,9 @@ impl Sampler for Memcache {
                                                 Some(self.general_config().window()),
                                             )),
                                         );
-                                        self.common().metrics().add_output(&statistic, Output::Reading);
+                                        self.common()
+                                            .metrics()
+                                            .add_output(&statistic, Output::Reading);
                                         self.common()
                                             .metrics()
                                             .record_counter(&statistic, time, value);
@@ -152,11 +153,10 @@ impl Sampler for Memcache {
                                         value.parse::<f64>().map(|v| v.floor() as u64)
                                     {
                                         let statistic = MemcacheStatistic::new((*name).to_string());
-                                        self.common().metrics().register(
-                                            &statistic,
-                                            None,
-                                        );
-                                        self.common().metrics().add_output(&statistic, Output::Reading);
+                                        self.common().metrics().register(&statistic, None);
+                                        self.common()
+                                            .metrics()
+                                            .add_output(&statistic, Output::Reading);
                                         // gauge type is used to pass-through raw metrics
                                         self.common()
                                             .metrics()

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::io::{Read, Write};
 
 use async_trait::async_trait;
 use rustcommon_metrics::*;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+// use tokio::io::{AsyncReadExt, AsyncWriteExt};
+// use tokio::net::TcpStream;
 
 use crate::config::*;
 use crate::samplers::Common;
@@ -23,27 +24,6 @@ pub struct Memcache {
     address: SocketAddr,
     common: Common,
     stream: Option<TcpStream>,
-}
-
-impl Memcache {
-    fn reconnect(&mut self) {
-        if self.stream.is_none() {
-            match std::net::TcpStream::connect(self.address) {
-                Ok(stream) => match TcpStream::from_std(stream) {
-                    Ok(stream) => {
-                        info!("Connected to memcache");
-                        self.stream = Some(stream)
-                    }
-                    Err(e) => {
-                        error!("Failed to create tokio TcpStream: {}", e);
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to connect to memcache: {}", e);
-                }
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -112,21 +92,24 @@ impl Sampler for Memcache {
         }
 
         if let Some(ref mut stream) = self.stream {
-            stream.write_all(b"stats\r\n").await?;
-            let mut buffer = [0_u8; 16355];
-            loop {
-                let length = stream.peek(&mut buffer).await?;
-                if length > 0 {
-                    let stats = std::str::from_utf8(&buffer).unwrap().to_string();
-                    let lines: Vec<&str> = stats.split("\r\n").collect();
-                    if lines.len() >= 2 && lines[lines.len() - 2] == "END" {
-                        break;
+
+            if stream.write_all(b"stats\r\n").is_ok() {
+                let mut buffer = [0_u8; 16355];
+                loop {
+                    if let Ok(length) = stream.read(&mut buffer) {
+                        if length == 0 {
+                            error!("zero length read. disconnect");
+                            self.stream = None;
+                            return Ok(());
+                        }
+                        let stats = std::str::from_utf8(&buffer).unwrap().to_string();
+                        let lines: Vec<&str> = stats.split("\r\n").collect();
+                        if lines.len() >= 2 && lines[lines.len() - 2] == "END" {
+                            break;
+                        }
                     }
                 }
-            }
-            let time = time::precise_time_ns();
-            let length = stream.read(&mut buffer).await?;
-            if length > 0 {
+                let time = time::precise_time_ns();
                 let stats = std::str::from_utf8(&buffer).unwrap().to_string();
                 let lines: Vec<&str> = stats.split("\r\n").collect();
                 for line in lines {
@@ -150,6 +133,7 @@ impl Sampler for Memcache {
                                                 Some(self.general_config().window()),
                                             )),
                                         );
+                                        self.common().metrics().add_output(&statistic, Output::Reading);
                                         self.common()
                                             .metrics()
                                             .record_counter(&statistic, time, value);
@@ -168,6 +152,11 @@ impl Sampler for Memcache {
                                         value.parse::<f64>().map(|v| v.floor() as u64)
                                     {
                                         let statistic = MemcacheStatistic::new((*name).to_string());
+                                        self.common().metrics().register(
+                                            &statistic,
+                                            None,
+                                        );
+                                        self.common().metrics().add_output(&statistic, Output::Reading);
                                         // gauge type is used to pass-through raw metrics
                                         self.common()
                                             .metrics()
@@ -178,12 +167,14 @@ impl Sampler for Memcache {
                         }
                     }
                 }
-            } else {
-                error!("failed to get stats. disconnect");
-                self.stream = None;
             }
         } else {
-            self.reconnect();
+            if let Ok(stream) = TcpStream::connect(self.address) {
+                let _ = stream.set_nonblocking(true);
+                self.stream = Some(stream);
+            } else {
+                error!("error connecting to memcache");
+            }
         }
 
         Ok(())

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -47,7 +47,9 @@ impl Sampler for Scheduler {
             perf: None,
         };
 
-        sampler.register();
+        if sampler.sampler_config().enabled() {
+            sampler.register();
+        }
 
         if let Err(e) = sampler.initialize_bpf() {
             if !fault_tolerant {


### PR DESCRIPTION
Problem

Memcache sampler currently causes a panic of the tokio worker.

Solution

Move from tokio async tcp stream to std non-blocking tcp stream.

Result

Memcache sampler functions properly.
