### PR TITLE
ci: ignore RUSTSEC-2020-0031

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -198,4 +198,4 @@ jobs:
     - name: install
       run: cargo install cargo-audit
     - name: audit
-      run: cargo audit
+      run: cargo audit --ignore RUSTSEC-2020-0031


### PR DESCRIPTION
Ignore this rustsec advisory, as with the simple HTTP API, we are
not impacted. #155 to follow-up with possibly migrating away from
tiny_http
