### PR TITLE
reduce runtime allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,12 +843,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1122,6 +1190,9 @@ dependencies = [
  "failure",
  "json",
  "kafka",
+ "num",
+ "num-derive",
+ "num-traits",
  "regex",
  "reqwest",
  "rustcommon-atomics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ ctrlc = { version = "3.1.3", features = ["termination"] }
 failure = "0.1.6"
 json = "0.12.1"
 kafka = { version = "0.8.0", optional = true }
+num = "0.3.0"
+num-traits = "0.2.12"
+num-derive = "0.3.2"
 regex = "1.3.4"
 reqwest = { version = "0.10.6", features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -56,18 +56,6 @@ pub enum DiskStatistic {
 }
 
 impl DiskStatistic {
-    pub fn diskstat_field(self) -> Option<usize> {
-        match self {
-            Self::BandwidthRead => Some(5),
-            Self::BandwidthWrite => Some(9),
-            Self::BandwidthDiscard => Some(16),
-            Self::OperationsRead => Some(3),
-            Self::OperationsWrite => Some(7),
-            Self::OperationsDiscard => Some(14),
-            _ => None,
-        }
-    }
-
     pub fn bpf_table(self) -> Option<&'static str> {
         match self {
             Self::LatencyRead => Some("latency_read"),

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -47,12 +47,15 @@ impl Sampler for Memcache {
         let address = addrs.next().unwrap_or_else(|| {
             fatal!("ERROR: failed to resolve address: {}", endpoint);
         });
-        let ret = Self {
+        let sampler = Self {
             address,
             common,
             stream: None,
         };
-        Ok(ret)
+        if sampler.sampler_config().enabled() {
+            sampler.register();
+        }
+        Ok(sampler)
     }
 
     fn spawn(common: Common) {

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -3,6 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
+use std::io::SeekFrom;
 
 use async_trait::async_trait;
 use tokio::fs::File;
@@ -29,6 +30,9 @@ pub fn nanos_per_tick() -> u64 {
 pub struct Rezolus {
     common: Common,
     nanos_per_tick: u64,
+    proc_stat: Option<File>,
+    proc_statm: Option<File>,
+    statistics: Vec<RezolusStatistic>,
 }
 
 #[async_trait]
@@ -36,10 +40,18 @@ impl Sampler for Rezolus {
     type Statistic = RezolusStatistic;
 
     fn new(common: Common) -> Result<Self, failure::Error> {
-        Ok(Self {
+        let statistics = common.config().samplers().rezolus().statistics();
+        let sampler = Self {
             common,
             nanos_per_tick: nanos_per_tick() as u64,
-        })
+            proc_stat: None,
+            proc_statm: None,
+            statistics,
+        };
+        if sampler.sampler_config().enabled() {
+            sampler.register();
+        }
+        Ok(sampler)
     }
 
     fn spawn(common: Common) {
@@ -78,58 +90,80 @@ impl Sampler for Rezolus {
         }
 
         debug!("sampling");
-        self.map_result(self.sample_memory().await)?;
-        self.map_result(self.sample_cpu().await)?;
+        let r = self.sample_memory().await;
+        self.map_result(r)?;
+
+        let r = self.sample_cpu().await;
+        self.map_result(r)?;
 
         Ok(())
     }
 }
 
 impl Rezolus {
-    async fn sample_cpu(&self) -> Result<(), std::io::Error> {
-        self.register();
-        let pid: u32 = std::process::id();
-        let mut result = HashMap::new();
-        let path = format!("/proc/{}/stat", pid);
-        let file = File::open(path).await?;
-        let reader = BufReader::new(file);
-        let mut lines = reader.lines();
-        while let Some(line) = lines.next_line().await? {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            let user = parts.get(13).map(|v| v.parse().unwrap_or(0)).unwrap_or(0)
-                + parts.get(15).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
-            let system = parts.get(14).map(|v| v.parse().unwrap_or(0)).unwrap_or(0)
-                + parts.get(16).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
-            result.insert(RezolusStatistic::CpuUser, user * self.nanos_per_tick);
-            result.insert(RezolusStatistic::CpuSystem, system * self.nanos_per_tick);
+    async fn sample_cpu(&mut self) -> Result<(), std::io::Error> {
+        if self.proc_stat.is_none() {
+            let pid: u32 = std::process::id();
+            let path = format!("/proc/{}/stat", pid);
+            let file = File::open(path).await?;
+            self.proc_stat = Some(file);
         }
 
-        let time = Instant::now();
-        for (stat, value) in result {
-            let _ = self.metrics().record_counter(&stat, time, value);
+        if let Some(file) = &mut self.proc_stat {
+            file.seek(SeekFrom::Start(0)).await?;
+            let mut reader = BufReader::new(file);
+            let mut result = HashMap::new();
+            let mut line = String::new();
+            if reader.read_line(&mut line).await? > 0 {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                let user = parts.get(13).map(|v| v.parse().unwrap_or(0)).unwrap_or(0)
+                    + parts.get(15).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
+                let system = parts.get(14).map(|v| v.parse().unwrap_or(0)).unwrap_or(0)
+                    + parts.get(16).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
+                result.insert(RezolusStatistic::CpuUser, user * self.nanos_per_tick);
+                result.insert(RezolusStatistic::CpuSystem, system * self.nanos_per_tick);
+            }
+
+            let time = Instant::now();
+            for statistic in &self.statistics {
+                if let Some(value) = result.get(statistic) {
+                    let _ = self.metrics().record_counter(statistic, time, *value);
+                }
+            }
         }
+
         Ok(())
     }
 
-    async fn sample_memory(&self) -> Result<(), std::io::Error> {
-        let pid: u32 = std::process::id();
-        let mut result_memory = HashMap::new();
-        let path = format!("/proc/{}/statm", pid);
-        let file = File::open(path).await?;
-        let reader = BufReader::new(file);
-        let mut lines = reader.lines();
-        while let Some(line) = lines.next_line().await? {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            let vm = parts.get(0).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
-            let rss = parts.get(1).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
-            result_memory.insert(RezolusStatistic::MemoryVirtual, vm);
-            result_memory.insert(RezolusStatistic::MemoryResident, rss);
+    async fn sample_memory(&mut self) -> Result<(), std::io::Error> {
+        if self.proc_statm.is_none() {
+            let pid: u32 = std::process::id();
+            let path = format!("/proc/{}/statm", pid);
+            let file = File::open(path).await?;
+            self.proc_statm = Some(file);
         }
 
-        let time = Instant::now();
-        for (stat, value) in result_memory {
-            let _ = self.metrics().record_gauge(&stat, time, value * 4096);
+        if let Some(file) = &mut self.proc_statm {
+            file.seek(SeekFrom::Start(0)).await?;
+            let mut result_memory = HashMap::new();
+            let mut reader = BufReader::new(file);
+            let mut line = String::new();
+            if reader.read_line(&mut line).await? > 0 {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                let vm = parts.get(0).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
+                let rss = parts.get(1).map(|v| v.parse().unwrap_or(0)).unwrap_or(0);
+                result_memory.insert(RezolusStatistic::MemoryVirtual, vm);
+                result_memory.insert(RezolusStatistic::MemoryResident, rss);
+            }
+
+            let time = Instant::now();
+            for statistic in &self.statistics {
+                if let Some(value) = result_memory.get(statistic) {
+                    let _ = self.metrics().record_gauge(statistic, time, *value * 4096);
+                }
+            }
         }
+
         Ok(())
     }
 }

--- a/src/samplers/softnet/stat.rs
+++ b/src/samplers/softnet/stat.rs
@@ -5,6 +5,7 @@
 use core::convert::TryFrom;
 use core::str::FromStr;
 
+use num_derive::FromPrimitive;
 use rustcommon_metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
@@ -18,6 +19,7 @@ use strum_macros::{EnumIter, EnumString, IntoStaticStr};
     EnumIter,
     EnumString,
     Eq,
+    FromPrimitive,
     IntoStaticStr,
     PartialEq,
     Hash,

--- a/src/samplers/xfs/config.rs
+++ b/src/samplers/xfs/config.rs
@@ -61,6 +61,16 @@ impl SamplerConfig for XfsConfig {
     }
 
     fn statistics(&self) -> Vec<<Self as SamplerConfig>::Statistic> {
-        self.statistics.clone()
+        let mut enabled = Vec::new();
+        for statistic in self.statistics.iter() {
+            if statistic.bpf_table().is_some() {
+                if self.bpf() {
+                    enabled.push(statistic.clone());
+                }
+            } else {
+                enabled.push(statistic.clone());
+            }
+        }
+        enabled
     }
 }

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -23,6 +23,7 @@ pub struct Xfs {
     bpf: Option<Arc<Mutex<BPF>>>,
     bpf_last: Arc<Mutex<Instant>>,
     common: Common,
+    statistics: Vec<XfsStatistic>,
 }
 
 #[async_trait]
@@ -30,18 +31,24 @@ impl Sampler for Xfs {
     type Statistic = XfsStatistic;
     fn new(common: Common) -> Result<Self, failure::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
+        let statistics = common.config().samplers().xfs().statistics();
 
         #[allow(unused_mut)]
         let mut sampler = Self {
             bpf: None,
             bpf_last: Arc::new(Mutex::new(Instant::now())),
             common,
+            statistics,
         };
 
         if let Err(e) = sampler.initialize_bpf() {
             if !fault_tolerant {
                 return Err(e);
             }
+        }
+
+        if sampler.sampler_config().enabled() {
+            sampler.register();
         }
 
         Ok(sampler)
@@ -83,7 +90,6 @@ impl Sampler for Xfs {
         }
 
         debug!("sampling");
-        self.register();
 
         // sample bpf
         #[cfg(feature = "bpf")]
@@ -98,7 +104,7 @@ impl Xfs {
     #[cfg(feature = "bpf")]
     fn bpf_enabled(&self) -> bool {
         if self.sampler_config().bpf() {
-            for statistic in self.sampler_config().statistics() {
+            for statistic in &self.statistics {
                 if statistic.bpf_table().is_some() {
                     return true;
                 }
@@ -165,14 +171,14 @@ impl Xfs {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();
                 let time = Instant::now();
-                for statistic in self.sampler_config().statistics() {
+                for statistic in &self.statistics {
                     if let Some(table) = statistic.bpf_table() {
                         let mut table = (*bpf).inner.table(table);
 
                         for (&value, &count) in &map_from_table(&mut table) {
                             if count > 0 {
                                 let _ = self.metrics().record_bucket(
-                                    &statistic,
+                                    statistic,
                                     time,
                                     value * crate::MICROSECOND,
                                     count,


### PR DESCRIPTION
Reduce runtime allocations by keeping open filehandles and seeking
back to start. This should reduce the syscall load, by reducing the
open-close behavior to a seek.

Additional changes to parsing to cache regex or replace them with
plain string parsing, again reducing runtime allocations.

Caching of enabled statistics in the sampler structs to avoid
repeated allocations which return a vec of statistics.
