### PR TITLE
use anyhow for error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,28 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -1166,11 +1150,11 @@ dependencies = [
 name = "rezolus"
 version = "2.7.2-alpha.3"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bcc",
  "clap",
  "ctrlc",
- "failure",
  "json",
  "kafka",
  "num",
@@ -1414,18 +1398,6 @@ checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ edition = '2018'
 description = "High resolution systems performance telemetry agent"
 
 [dependencies]
+anyhow = "1.0.32"
 async-trait = "0.1.40"
 bcc = { version = "0.0.25", optional = true }
 clap = "2.33.3"
 ctrlc = { version = "3.1.6", features = ["termination"] }
-failure = "0.1.8"
 json = "0.12.4"
 kafka = { version = "0.8.0", optional = true }
 num = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 extern crate rustcommon_logger;
 
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 
 use rustcommon_atomics::{Atomic, Ordering};
 use std::sync::Arc;

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -53,7 +53,7 @@ pub fn nanos_per_tick() -> u64 {
 impl Sampler for Cpu {
     type Statistic = CpuStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let statistics = common.config().samplers().cpu().statistics();
         #[allow(unused_mut)]
         let mut sampler = Self {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -37,7 +37,7 @@ pub struct Disk {
 impl Sampler for Disk {
     type Statistic = DiskStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().disk().statistics();
 
@@ -124,7 +124,7 @@ impl Disk {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -29,7 +29,7 @@ pub struct Ext4 {
 #[async_trait]
 impl Sampler for Ext4 {
     type Statistic = Ext4Statistic;
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().ext4().statistics();
 
@@ -113,7 +113,7 @@ impl Ext4 {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/http/mod.rs
+++ b/src/samplers/http/mod.rs
@@ -29,7 +29,7 @@ pub struct Http {
 impl Sampler for Http {
     type Statistic = HttpStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let url = common.config.samplers().http().url();
         let passthrough = common.config.samplers().http().passthrough();
         if url.is_none() && common.config.samplers().http().enabled() {

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -33,7 +33,7 @@ pub struct Interrupt {
 impl Sampler for Interrupt {
     type Statistic = InterruptStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().interrupt().statistics();
 
@@ -117,7 +117,7 @@ impl Interrupt {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -29,7 +29,7 @@ pub struct Memcache {
 impl Sampler for Memcache {
     type Statistic = MemcacheStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         if !common.config.samplers().memcache().enabled() {
             return Ok(Self {
                 address: "localhost:11211".to_socket_addrs().unwrap().next().unwrap(),

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -33,7 +33,7 @@ pub struct Memory {
 impl Sampler for Memory {
     type Statistic = MemoryStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let statistics = common.config().samplers().memory().statistics();
         let sampler = Self { common, statistics };
         if sampler.sampler_config().enabled() {

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -48,7 +48,7 @@ pub trait Sampler: Sized + Send {
     type Statistic: Statistic<AtomicU64, AtomicU32>;
 
     /// Create a new instance of the sampler
-    fn new(common: Common) -> Result<Self, failure::Error>;
+    fn new(common: Common) -> Result<Self, anyhow::Error>;
 
     /// Access common fields shared between samplers
     fn common(&self) -> &Common;

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -33,7 +33,7 @@ pub struct Network {
 impl Sampler for Network {
     type Statistic = NetworkStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().network().statistics();
 
@@ -116,7 +116,7 @@ impl Network {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -39,7 +39,7 @@ pub struct Rezolus {
 impl Sampler for Rezolus {
     type Statistic = RezolusStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let statistics = common.config().samplers().rezolus().statistics();
         let sampler = Self {
             common,

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -39,7 +39,7 @@ pub struct Scheduler {
 #[async_trait]
 impl Sampler for Scheduler {
     type Statistic = SchedulerStatistic;
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().scheduler().statistics();
 
@@ -301,7 +301,7 @@ impl Scheduler {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -30,7 +30,7 @@ pub struct Softnet {
 #[async_trait]
 impl Sampler for Softnet {
     type Statistic = SoftnetStatistic;
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let statistics = common.config().samplers().softnet().statistics();
         let sampler = Self {
             common,

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -31,7 +31,7 @@ pub struct Tcp {
 #[async_trait]
 impl Sampler for Tcp {
     type Statistic = TcpStatistic;
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().tcp().statistics();
 
@@ -123,7 +123,7 @@ impl Tcp {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {

--- a/src/samplers/udp/mod.rs
+++ b/src/samplers/udp/mod.rs
@@ -28,7 +28,7 @@ pub struct Udp {
 impl Sampler for Udp {
     type Statistic = UdpStatistic;
 
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let statistics = common.config().samplers().udp().statistics();
 
         let sampler = Self {

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -29,7 +29,7 @@ pub struct Xfs {
 #[async_trait]
 impl Sampler for Xfs {
     type Statistic = XfsStatistic;
-    fn new(common: Common) -> Result<Self, failure::Error> {
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
         let fault_tolerant = common.config.general().fault_tolerant();
         let statistics = common.config().samplers().xfs().statistics();
 
@@ -113,7 +113,7 @@ impl Xfs {
         false
     }
 
-    fn initialize_bpf(&mut self) -> Result<(), failure::Error> {
+    fn initialize_bpf(&mut self) -> Result<(), anyhow::Error> {
         #[cfg(feature = "bpf")]
         {
             if self.enabled() && self.bpf_enabled() {


### PR DESCRIPTION
Modernize error handling by replacing failure with anyhow.
