### PR TITLE
fix scheduler and memory samplers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "2.7.2-alpha.3"
+version = "2.7.2-alpha.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "2.7.2-alpha.3"
+version = "2.7.2-alpha.4"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 license = "Apache-2.0"
 build = "build.rs"

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -155,11 +155,17 @@ impl Memory {
         }
 
         let time = Instant::now();
-        for stat in &self.statistics {
-            if let Some(value) = result.get(stat) {
-                let _ = self
-                    .metrics()
-                    .record_gauge(stat, time, *value * stat.multiplier());
+        for statistic in &self.statistics {
+            if let Some(value) = result.get(statistic) {
+                match statistic.source() {
+                    Source::Counter => {
+                        let _ = self.metrics().record_counter(statistic, time, *value);
+                    }
+                    Source::Gauge => {
+                        let _ = self.metrics().record_gauge(statistic, time, *value);
+                    }
+                    _ => {}
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Bug in the parser logic for /proc/stat introduced since 2.7.1

Gauge statistics were not being updated properly for scheduler and
memory samplers.