### PR TITLE
reduce cost of disabled samplers

### DIFF
--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -94,16 +94,18 @@ impl Sampler for Cpu {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut cpu) = Cpu::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = cpu.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize cpu sampler");
-        } else {
-            error!("failed to initialize cpu sampler");
+        if common.config().samplers().cpu().enabled() {
+            if let Ok(mut cpu) = Cpu::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = cpu.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize cpu sampler");
+            } else {
+                error!("failed to initialize cpu sampler");
+            }
         }
     }
 

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -65,16 +65,18 @@ impl Sampler for Disk {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize disk sampler");
-        } else {
-            error!("failed to initialize disk sampler");
+        if common.config().samplers().disk().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize disk sampler");
+            } else {
+                error!("failed to initialize disk sampler");
+            }
         }
     }
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -55,16 +55,18 @@ impl Sampler for Ext4 {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize ext4 sampler");
-        } else {
-            error!("failed to initialize ext4 sampler");
+        if common.config().samplers().ext4().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize ext4 sampler");
+            } else {
+                error!("failed to initialize ext4 sampler");
+            }
         }
     }
 

--- a/src/samplers/http/mod.rs
+++ b/src/samplers/http/mod.rs
@@ -46,16 +46,18 @@ impl Sampler for Http {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize http sampler");
-        } else {
-            error!("failed to initialize http sampler");
+        if common.config().samplers().http().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize http sampler");
+            } else {
+                error!("failed to initialize http sampler");
+            }
         }
     }
 

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -59,16 +59,18 @@ impl Sampler for Interrupt {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut interrupt) = Interrupt::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = interrupt.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize interrupt sampler");
-        } else {
-            error!("failed to initialize interrupt sampler");
+        if common.config().samplers().interrupt().enabled() {
+            if let Ok(mut interrupt) = Interrupt::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = interrupt.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize interrupt sampler");
+            } else {
+                error!("failed to initialize interrupt sampler");
+            }
         }
     }
 

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -59,16 +59,18 @@ impl Sampler for Memcache {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize memcache sampler");
-        } else {
-            error!("failed to initialize memcache sampler");
+        if common.config().samplers().memcache().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize memcache sampler");
+            } else {
+                error!("failed to initialize memcache sampler");
+            }
         }
     }
 

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -43,16 +43,18 @@ impl Sampler for Memory {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize memory sampler");
-        } else {
-            error!("failed to initialize memory sampler");
+        if common.config().samplers().memory().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize memory sampler");
+            } else {
+                error!("failed to initialize memory sampler");
+            }
         }
     }
 

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -59,16 +59,18 @@ impl Sampler for Network {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize network sampler");
-        } else {
-            error!("failed to initialize network sampler");
+        if common.config().samplers().network().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize network sampler");
+            } else {
+                error!("failed to initialize network sampler");
+            }
         }
     }
 

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -56,16 +56,18 @@ impl Sampler for PageCache {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut interrupt) = PageCache::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = interrupt.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize page_cache sampler");
-        } else {
-            error!("failed to initialize page_cache sampler");
+        if common.config().samplers().page_cache().enabled() {
+            if let Ok(mut interrupt) = PageCache::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = interrupt.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize page_cache sampler");
+            } else {
+                error!("failed to initialize page_cache sampler");
+            }
         }
     }
 

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -55,16 +55,18 @@ impl Sampler for Rezolus {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize rezolus sampler");
-        } else {
-            error!("failed to initialize rezolus sampler");
+        if common.config().samplers().rezolus().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize rezolus sampler");
+            } else {
+                error!("failed to initialize rezolus sampler");
+            }
         }
     }
 

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -86,16 +86,18 @@ impl Sampler for Scheduler {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize scheduler sampler");
-        } else {
-            error!("failed to initialize scheduler sampler");
+        if common.config().samplers().scheduler().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize scheduler sampler");
+            } else {
+                error!("failed to initialize scheduler sampler");
+            }
         }
     }
 

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -44,16 +44,18 @@ impl Sampler for Softnet {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize softnet sampler");
-        } else {
-            error!("failed to initialize softnet sampler");
+        if common.config().samplers().softnet().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize softnet sampler");
+            } else {
+                error!("failed to initialize softnet sampler");
+            }
         }
     }
 

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -59,16 +59,18 @@ impl Sampler for Tcp {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize tcp sampler");
-        } else {
-            error!("failed to initialize tcp sampler");
+        if common.config().samplers().tcp().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize tcp sampler");
+            } else {
+                error!("failed to initialize tcp sampler");
+            }
         }
     }
 

--- a/src/samplers/udp/mod.rs
+++ b/src/samplers/udp/mod.rs
@@ -44,16 +44,18 @@ impl Sampler for Udp {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize udp sampler");
-        } else {
-            error!("failed to initialize udp sampler");
+        if common.config().samplers().udp().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize udp sampler");
+            } else {
+                error!("failed to initialize udp sampler");
+            }
         }
     }
 

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -55,16 +55,18 @@ impl Sampler for Xfs {
     }
 
     fn spawn(common: Common) {
-        if let Ok(mut sampler) = Self::new(common.clone()) {
-            common.handle.spawn(async move {
-                loop {
-                    let _ = sampler.sample().await;
-                }
-            });
-        } else if !common.config.fault_tolerant() {
-            fatal!("failed to initialize xfs sampler");
-        } else {
-            error!("failed to initialize xfs sampler");
+        if common.config().samplers().xfs().enabled() {
+            if let Ok(mut sampler) = Self::new(common.clone()) {
+                common.handle.spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize xfs sampler");
+            } else {
+                error!("failed to initialize xfs sampler");
+            }
         }
     }
 


### PR DESCRIPTION
Prevents the initialization of disabled samplers within the `spawn`
function. This should help reduce allocations and initialization
costs when a sampler is disabled, bringing it more in line with
"pay for what you use".
