### PR TITLE
add proper NUMA node identification to interrupt sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ dependencies = [
  "bcc",
  "clap",
  "ctrlc",
+ "dashmap",
  "json",
  "kafka",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1.40"
 bcc = { version = "0.0.25", optional = true }
 clap = "2.33.3"
 ctrlc = { version = "3.1.6", features = ["termination"] }
+dashmap = "3.11.10"
 json = "0.12.4"
 kafka = { version = "0.8.0", optional = true }
 num = "0.3.0"

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use std::io::BufRead;
 use std::io::SeekFrom;
 
+use dashmap::DashMap;
+use rustcommon_atomics::AtomicU64;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -18,6 +20,56 @@ pub const SECOND: u64 = 1_000 * MILLISECOND;
 pub const MILLISECOND: u64 = 1_000 * MICROSECOND;
 pub const MICROSECOND: u64 = 1_000 * NANOSECOND;
 pub const NANOSECOND: u64 = 1;
+
+pub struct HardwareInfo {
+    hardware_threads: AtomicU64,
+    numa_mapping: DashMap<u64, u64>,
+}
+
+impl HardwareInfo {
+    pub fn new() -> Self {
+        let hardware_threads = hardware_threads().unwrap_or(1);
+        let numa_mapping = DashMap::new();
+        let mut node = 0;
+        loop {
+            let path = format!("/sys/devices/system/node/node{}/cpulist", node);
+            if let Ok(f) = std::fs::File::open(path) {
+                let mut reader = std::io::BufReader::new(f);
+                let mut line = String::new();
+                if reader.read_line(&mut line).is_ok() {
+                    let ranges: Vec<&str> = line.trim().split(',').collect();
+                    for range in ranges {
+                        let parts: Vec<&str> = range.split('-').collect();
+                        if parts.len() == 1 {
+                            if let Ok(id) = parts[0].parse() {
+                                numa_mapping.insert(id, node);
+                            }
+                        } else if parts.len() == 2 {
+                            if let Ok(start) = parts[0].parse() {
+                                if let Ok(stop) = parts[1].parse() {
+                                    for id in start..=stop {
+                                        numa_mapping.insert(id, node);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                break;
+            }
+            node += 1;
+        } 
+        Self {
+            hardware_threads: AtomicU64::new(hardware_threads),
+            numa_mapping,
+        }
+    }
+
+    pub fn get_numa(&self, core: u64) -> Option<u64> {
+        self.numa_mapping.get(&core).map(|v| *v.value())
+    }
+}
 
 /// helper function to discover the number of hardware threads
 pub fn hardware_threads() -> Result<u64, ()> {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -59,7 +59,7 @@ impl HardwareInfo {
                 break;
             }
             node += 1;
-        } 
+        }
         Self {
             hardware_threads: AtomicU64::new(hardware_threads),
             numa_mapping,

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -170,15 +170,16 @@ impl Interrupt {
             let mut node0 = 0;
             let mut node1 = 0;
             let cores = cores.unwrap();
+
             for i in 0..cores {
                 let count = parts.get(i + 1).unwrap_or(&"0").parse().unwrap_or(0);
                 sum += count;
-                // Assumes the system is split into 2 NUMA nodes with
-                // hyperthreading enabled and that cores are arranged as follows
-                if i < (cores / 4) || (i >= (cores / 2) && i < (3 * cores / 4)) {
-                    node0 += count;
-                } else {
-                    node1 += count;
+
+                let node = self.common().hardware_info().get_numa(i as u64).unwrap_or(0);
+                match node {
+                    0 => node0 += count,
+                    1 => node1 += count,
+                    _ => {},
                 }
             }
             let stat = match parts.get(0) {

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -175,11 +175,15 @@ impl Interrupt {
                 let count = parts.get(i + 1).unwrap_or(&"0").parse().unwrap_or(0);
                 sum += count;
 
-                let node = self.common().hardware_info().get_numa(i as u64).unwrap_or(0);
+                let node = self
+                    .common()
+                    .hardware_info()
+                    .get_numa(i as u64)
+                    .unwrap_or(0);
                 match node {
                     0 => node0 += count,
                     1 => node1 += count,
-                    _ => {},
+                    _ => {}
                 }
             }
             let stat = match parts.get(0) {

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::HardwareInfo;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::time::Duration;
@@ -160,6 +161,7 @@ pub trait Sampler: Sized + Send {
 pub struct Common {
     config: Arc<Config>,
     handle: Handle,
+    hardware_info: Arc<HardwareInfo>,
     interval: Option<Interval>,
     metrics: Arc<Metrics<AtomicU64, AtomicU32>>,
 }
@@ -169,6 +171,7 @@ impl Clone for Common {
         Self {
             config: self.config.clone(),
             handle: self.handle.clone(),
+            hardware_info: self.hardware_info.clone(),
             interval: None,
             metrics: self.metrics.clone(),
         }
@@ -184,6 +187,7 @@ impl Common {
         Self {
             config,
             handle,
+            hardware_info: Arc::new(HardwareInfo::new()),
             interval: None,
             metrics,
         }
@@ -191,6 +195,10 @@ impl Common {
 
     pub fn config(&self) -> &Config {
         &self.config
+    }
+
+    pub fn hardware_info(&self) -> &HardwareInfo {
+        &self.hardware_info
     }
 
     pub fn interval(&mut self) -> &mut Option<Interval> {


### PR DESCRIPTION
Removes assumptions about NUMA node mapping in the interrupt
sampler.

Adds a `HardwareInfo` struct to `Sampler::Common` which contains
a NUMA node mapping by parsing sysfs.
