### PR TITLE
remove dead code in hardwareinfo struct

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -58,9 +58,7 @@ impl HardwareInfo {
             }
             node += 1;
         }
-        Self {
-            numa_mapping,
-        }
+        Self { numa_mapping }
     }
 
     pub fn get_numa(&self, core: u64) -> Option<u64> {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -22,13 +22,11 @@ pub const MICROSECOND: u64 = 1_000 * NANOSECOND;
 pub const NANOSECOND: u64 = 1;
 
 pub struct HardwareInfo {
-    hardware_threads: AtomicU64,
     numa_mapping: DashMap<u64, u64>,
 }
 
 impl HardwareInfo {
     pub fn new() -> Self {
-        let hardware_threads = hardware_threads().unwrap_or(1);
         let numa_mapping = DashMap::new();
         let mut node = 0;
         loop {
@@ -61,7 +59,6 @@ impl HardwareInfo {
             node += 1;
         }
         Self {
-            hardware_threads: AtomicU64::new(hardware_threads),
             numa_mapping,
         }
     }


### PR DESCRIPTION
We're not using the hardware thread count in any samplers, remove
it from the struct.
