### PR TITLE
update rustcommon for metrics performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "2.8.1-alpha.1"
+version = "2.8.1-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "serde",
 ]
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "rustcommon-atomics",
  "rustcommon-histogram",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "log 0.4.11",
  "time",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "dashmap",
  "rustcommon-atomics",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#edc363e8e4279bf29f65088f2766b3cbc1e71888"
+source = "git+https://github.com/twitter/rustcommon#c8667fe0e9af4161597d751989e98d3e52e09172"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "2.8.1-alpha.1"
+version = "2.8.1-alpha.2"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 license = "Apache-2.0"
 build = "build.rs"


### PR DESCRIPTION
Pulls in changes in rustcommon-metrics which provide performance
improvements for updating metrics with new values.

See https://github.com/twitter/rustcommon/pull/40 for details.