### PR TITLE
remove rustfmt license text check

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -203,9 +203,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install rustfmt
-      run: rustup +nightly component add rustfmt
+      run: rustup component add rustfmt
     - name: rustfmt
-      run: cargo +nightly fmt -- --check
+      run: cargo fmt -- --check
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/license_template.txt
+++ b/license_template.txt
@@ -1,3 +1,0 @@
-// Copyright {[\d-]+} Twitter, Inc.
-// Licensed under the Apache License, Version 2.0
-// http://www.apache.org/licenses/LICENSE-2.0

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-license_template_path = "license_template.txt"


### PR DESCRIPTION
The license text check requires nightly rustfmt which isn't always
present in a nightly build. This can cause unrelated CI failures
when there is breakage in upstream rust nightly builds.

Changes rustfmt to stable version and removes license template and
rustfmt config.
