### PR TITLE
fix disk bpf sampler on newer kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "serde",
 ]
@@ -1391,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "log 0.4.11",
  "time",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "crossbeam",
  "dashmap",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
+source = "git+https://github.com/twitter/rustcommon#1fa5045c2ebc83afa8705bb5f09c95e7f4e62c73"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -174,6 +174,9 @@ bpf = true
 # Controls whether to use this sampler
 enabled = true
 
+# Enable BPF sampling
+bpf = true
+
 # Sampling interval, in milliseconds, for this sampler
 # interval = 1000
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -42,6 +42,7 @@ impl Sampler for Ext4 {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -49,6 +49,7 @@ impl Sampler for Interrupt {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -49,6 +49,7 @@ impl Sampler for Network {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -43,6 +43,7 @@ impl Sampler for PageCache {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -59,6 +59,7 @@ impl Sampler for Scheduler {
         }
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }
@@ -69,6 +70,7 @@ impl Sampler for Scheduler {
             #[cfg(feature = "bpf")]
             {
                 if let Err(e) = sampler.initialize_bpf_perf() {
+                    error!("{}", e);
                     if !fault_tolerant {
                         return Err(format_err!("bpf perf init failure: {}", e));
                     }

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -46,6 +46,7 @@ impl Sampler for Tcp {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -42,6 +42,7 @@ impl Sampler for Xfs {
         };
 
         if let Err(e) = sampler.initialize_bpf() {
+            error!("{}", e);
             if !fault_tolerant {
                 return Err(e);
             }


### PR DESCRIPTION
Fixes the disk bpf sampler on newer kernels by attempting to detect
whether some specific kprobe functions exist before loading.

Adds better error messaging for bpf initialization failures.

Fixes #137 