### PR TITLE
add nvidia gpu sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -355,6 +355,41 @@ checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
 dependencies = [
  "nix",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -670,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +815,16 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "libloading"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "lock_api"
@@ -1058,6 +1109,29 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6fb95ab904553d1b8914d340cadd0b34bee1cc984668eaa096a018f04ed8b8"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be195fa681ad2a9c903a866bc3f97f174333f04fb7b9e7c1f2413452f698484"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1356,6 +1430,7 @@ dependencies = [
  "num",
  "num-derive",
  "num-traits",
+ "nvml-wrapper",
  "regex",
  "reqwest",
  "rustcommon-atomics",
@@ -1587,6 +1662,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strum"
@@ -2101,6 +2182,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc065c85ad2c3bd12aa4118bf164835712e25080c392557801a13292c60aec"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ libc = "0.2.80"
 num = "0.3.1"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
+nvml-wrapper = "0.7.0"
 regex = "1.4.2"
 reqwest = { version = "0.10.8", features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -274,6 +274,33 @@ enabled = true
 # 	"p99",
 # ]
 
+# The Nvidia sampler provides telemetry for Nvidia GPUs by using the NVML
+# library.
+[samplers.nvidia]
+# Controls whether to use this sampler
+enabled = true
+
+# Sampling interval, in milliseconds, for this sampler
+# interval = 1000
+
+# The set of exported statistics may be limited by specifying them, otherwise
+# the complete set of statistics will be exported.
+# NOTE: the lack of the 'nvidia' prefix. Exported stats will have the form of
+# nvidia/gpu_[id]/...
+# statistics = [
+# 	"gpu/temperature",
+#   "power/usage",
+#   "power/limit",
+# ]
+
+# The set of exported percentiles can be controlled by specifying them here
+# percentiles = [
+# 	"p1",
+# 	"p10",
+# 	"p50",
+# 	"p90",
+# 	"p99",
+# ]
 
 # The page cache sampler provides telemetry about page cache hits and misses
 [samplers.page_cache]

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -327,6 +327,41 @@ Provides system-wide network telemetry
 * `network/receive/size` - size distribution, in bytes, of received packets
 * `network/transmit/size` - size distribution, in bytes, of transmitted packets
 
+## Nvidia
+
+Telemetry for Nvidia GPUs, collected by using the Nvidia Management Library
+(NVML). Unlike other samplers, these stats are fully scoped to specific GPUs
+within the system. Exported metrics will have the form: `nvidia/gpu_[id]/...`
+where the id is the device identifier as reported by the NVML. The set of
+metrics to collect uses the short form of the metric name, as provided below.
+
+### Basic
+
+* `clock/sm/current` - current streaming multiprocessor clock speed in MHz
+* `clock/memory/current` - current memory clock speed in MHz
+* `decoder/utilization` - video decoder utilization as a percentage
+* `encoder/utilization` - video encoder utilization as a percentage
+* `energy/consumption` - total energy consumption since boot in mJ
+* `gpu/temperature` - current GPU temperature in °C
+* `cpu/utilization` - GPU utilzation as a percentage
+* `memory/ecc/enabled` - boolean (0 or 1) indicating if ECC is enabled
+* `memory/ecc/dbe` - count of double-bit errors (uncorrectable)
+* `memory/ecc/sbe` - count of single-bit errors (correctable)
+* `memory/fb/free` - framebuffer memory free in bytes
+* `memory/fb/total` - total framebuffer memory in bytes
+* `memory/fb/used` - framebuffer memory used in bytes
+* `memory/retired/sbe` - memory pages retired due to multiple single-bit errors
+* `memory/retired/dbe` - memory pages retired due to double-bit error
+* `memory/retired/pending` - boolean (0 or 1) indicating that memory pages are
+  pending retirement
+* `memory/utilization` - memory copy utilization as a percentage
+* `pcie/replay` - count of PCIe replays. May indicate link issues.
+* `pcie/rx/throughput` - PCIe receive throughput in KB/s
+* `pcie/tx/throughput` - PCIe transmit throughput in KB/s
+* `power/limit` - enforced power limit in mW
+* `power/usage` - current power usage in mW
+* `processes/compute` - number of processes running in compute context
+
 ## Page Cache
 
 The page cache is a transparent cache for pages originating from a secondary

--- a/src/config/samplers.rs
+++ b/src/config/samplers.rs
@@ -13,6 +13,7 @@ use samplers::memcache::MemcacheConfig;
 use samplers::memory::MemoryConfig;
 use samplers::network::NetworkConfig;
 use samplers::ntp::NtpConfig;
+use samplers::nvidia::NvidiaConfig;
 use samplers::page_cache::PageCacheConfig;
 use samplers::rezolus::RezolusConfig;
 use samplers::scheduler::SchedulerConfig;
@@ -42,6 +43,8 @@ pub struct Samplers {
     network: NetworkConfig,
     #[serde(default)]
     ntp: NtpConfig,
+    #[serde(default)]
+    nvidia: NvidiaConfig,
     #[serde(default)]
     page_cache: PageCacheConfig,
     #[serde(default)]
@@ -93,6 +96,10 @@ impl Samplers {
 
     pub fn ntp(&self) -> &NtpConfig {
         &self.ntp
+    }
+
+    pub fn nvidia(&self) -> &NvidiaConfig {
+        &self.nvidia
     }
 
     pub fn page_cache(&self) -> &PageCacheConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     PageCache::spawn(common.clone());
     Network::spawn(common.clone());
     Ntp::spawn(common.clone());
+    Nvidia::spawn(common.clone());
     Rezolus::spawn(common.clone());
     Scheduler::spawn(common.clone());
     Softnet::spawn(common.clone());

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -24,6 +24,7 @@ pub mod memcache;
 pub mod memory;
 pub mod network;
 pub mod ntp;
+pub mod nvidia;
 pub mod page_cache;
 pub mod rezolus;
 pub mod scheduler;
@@ -41,6 +42,7 @@ pub use memcache::Memcache;
 pub use memory::Memory;
 pub use network::Network;
 pub use ntp::Ntp;
+pub use nvidia::Nvidia;
 pub use page_cache::PageCache;
 pub use rezolus::Rezolus;
 pub use scheduler::Scheduler;
@@ -135,7 +137,7 @@ pub trait Sampler: Sized + Send {
     }
 
     fn samples(&self) -> usize {
-        (1000 / self.interval()) * self.general_config().window()
+        ((1000.0 / self.interval() as f64) * self.general_config().window() as f64).ceil() as usize
     }
 
     fn metrics(&self) -> &Metrics<AtomicU64, AtomicU32> {

--- a/src/samplers/nvidia/config.rs
+++ b/src/samplers/nvidia/config.rs
@@ -55,79 +55,80 @@ impl SamplerConfig for NvidiaConfig {
 
     fn statistics(&self) -> Vec<<Self as SamplerConfig>::Statistic> {
         let mut enabled = Vec::new();
-        let nvml = NVML::builder().init().expect("failed to initialize nvml");
-        let devices = nvml.device_count().unwrap_or(0);
-        for statistic in self.statistics.iter() {
-            for id in 0..devices {
-                match statistic {
-                    NvidiaConfigStatistic::GpuTemperature => {
-                        enabled.push(NvidiaStatistic::GpuTemperature(id));
-                    }
-                    NvidiaConfigStatistic::GpuUtilization => {
-                        enabled.push(NvidiaStatistic::GpuUtilization(id));
-                    }
-                    NvidiaConfigStatistic::MemoryEccEnabled => {
-                        enabled.push(NvidiaStatistic::MemoryEccEnabled(id));
-                    }
-                    NvidiaConfigStatistic::MemoryEccSbe => {
-                        enabled.push(NvidiaStatistic::MemoryEccSbe(id));
-                    }
-                    NvidiaConfigStatistic::MemoryEccDbe => {
-                        enabled.push(NvidiaStatistic::MemoryEccDbe(id));
-                    }
-                    NvidiaConfigStatistic::MemoryUtilization => {
-                        enabled.push(NvidiaStatistic::MemoryUtilization(id));
-                    }
-                    NvidiaConfigStatistic::EncoderUtilization => {
-                        enabled.push(NvidiaStatistic::EncoderUtilization(id));
-                    }
-                    NvidiaConfigStatistic::DecoderUtilization => {
-                        enabled.push(NvidiaStatistic::DecoderUtilization(id));
-                    }
-                    NvidiaConfigStatistic::PowerUsage => {
-                        enabled.push(NvidiaStatistic::PowerUsage(id));
-                    }
-                    NvidiaConfigStatistic::PowerLimit => {
-                        enabled.push(NvidiaStatistic::PowerLimit(id));
-                    }
-                    NvidiaConfigStatistic::EnergyConsumption => {
-                        enabled.push(NvidiaStatistic::EnergyConsumption(id));
-                    }
-                    NvidiaConfigStatistic::ClockSMCurrent => {
-                        enabled.push(NvidiaStatistic::ClockSMCurrent(id));
-                    }
-                    NvidiaConfigStatistic::ClockMemoryCurrent => {
-                        enabled.push(NvidiaStatistic::ClockMemoryCurrent(id));
-                    }
-                    NvidiaConfigStatistic::PcieReplay => {
-                        enabled.push(NvidiaStatistic::PcieReplay(id));
-                    }
-                    NvidiaConfigStatistic::PcieRxThroughput => {
-                        enabled.push(NvidiaStatistic::PcieRxThroughput(id));
-                    }
-                    NvidiaConfigStatistic::PcieTxThroughput => {
-                        enabled.push(NvidiaStatistic::PcieTxThroughput(id));
-                    }
-                    NvidiaConfigStatistic::MemoryFbFree => {
-                        enabled.push(NvidiaStatistic::MemoryFbFree(id));
-                    }
-                    NvidiaConfigStatistic::MemoryFbTotal => {
-                        enabled.push(NvidiaStatistic::MemoryFbTotal(id));
-                    }
-                    NvidiaConfigStatistic::MemoryFbUsed => {
-                        enabled.push(NvidiaStatistic::MemoryFbUsed(id));
-                    }
-                    NvidiaConfigStatistic::MemoryRetiredSbe => {
-                        enabled.push(NvidiaStatistic::MemoryRetiredSbe(id));
-                    }
-                    NvidiaConfigStatistic::MemoryRetiredDbe => {
-                        enabled.push(NvidiaStatistic::MemoryRetiredDbe(id));
-                    }
-                    NvidiaConfigStatistic::MemoryRetiredPending => {
-                        enabled.push(NvidiaStatistic::MemoryRetiredPending(id));
-                    }
-                    NvidiaConfigStatistic::ProcessesCompute => {
-                        enabled.push(NvidiaStatistic::ProcessesCompute(id));
+        if let Ok(nvml) = NVML::builder().init() {
+            let devices = nvml.device_count().unwrap_or(0);
+            for statistic in self.statistics.iter() {
+                for id in 0..devices {
+                    match statistic {
+                        NvidiaConfigStatistic::GpuTemperature => {
+                            enabled.push(NvidiaStatistic::GpuTemperature(id));
+                        }
+                        NvidiaConfigStatistic::GpuUtilization => {
+                            enabled.push(NvidiaStatistic::GpuUtilization(id));
+                        }
+                        NvidiaConfigStatistic::MemoryEccEnabled => {
+                            enabled.push(NvidiaStatistic::MemoryEccEnabled(id));
+                        }
+                        NvidiaConfigStatistic::MemoryEccSbe => {
+                            enabled.push(NvidiaStatistic::MemoryEccSbe(id));
+                        }
+                        NvidiaConfigStatistic::MemoryEccDbe => {
+                            enabled.push(NvidiaStatistic::MemoryEccDbe(id));
+                        }
+                        NvidiaConfigStatistic::MemoryUtilization => {
+                            enabled.push(NvidiaStatistic::MemoryUtilization(id));
+                        }
+                        NvidiaConfigStatistic::EncoderUtilization => {
+                            enabled.push(NvidiaStatistic::EncoderUtilization(id));
+                        }
+                        NvidiaConfigStatistic::DecoderUtilization => {
+                            enabled.push(NvidiaStatistic::DecoderUtilization(id));
+                        }
+                        NvidiaConfigStatistic::PowerUsage => {
+                            enabled.push(NvidiaStatistic::PowerUsage(id));
+                        }
+                        NvidiaConfigStatistic::PowerLimit => {
+                            enabled.push(NvidiaStatistic::PowerLimit(id));
+                        }
+                        NvidiaConfigStatistic::EnergyConsumption => {
+                            enabled.push(NvidiaStatistic::EnergyConsumption(id));
+                        }
+                        NvidiaConfigStatistic::ClockSMCurrent => {
+                            enabled.push(NvidiaStatistic::ClockSMCurrent(id));
+                        }
+                        NvidiaConfigStatistic::ClockMemoryCurrent => {
+                            enabled.push(NvidiaStatistic::ClockMemoryCurrent(id));
+                        }
+                        NvidiaConfigStatistic::PcieReplay => {
+                            enabled.push(NvidiaStatistic::PcieReplay(id));
+                        }
+                        NvidiaConfigStatistic::PcieRxThroughput => {
+                            enabled.push(NvidiaStatistic::PcieRxThroughput(id));
+                        }
+                        NvidiaConfigStatistic::PcieTxThroughput => {
+                            enabled.push(NvidiaStatistic::PcieTxThroughput(id));
+                        }
+                        NvidiaConfigStatistic::MemoryFbFree => {
+                            enabled.push(NvidiaStatistic::MemoryFbFree(id));
+                        }
+                        NvidiaConfigStatistic::MemoryFbTotal => {
+                            enabled.push(NvidiaStatistic::MemoryFbTotal(id));
+                        }
+                        NvidiaConfigStatistic::MemoryFbUsed => {
+                            enabled.push(NvidiaStatistic::MemoryFbUsed(id));
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredSbe => {
+                            enabled.push(NvidiaStatistic::MemoryRetiredSbe(id));
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredDbe => {
+                            enabled.push(NvidiaStatistic::MemoryRetiredDbe(id));
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredPending => {
+                            enabled.push(NvidiaStatistic::MemoryRetiredPending(id));
+                        }
+                        NvidiaConfigStatistic::ProcessesCompute => {
+                            enabled.push(NvidiaStatistic::ProcessesCompute(id));
+                        }
                     }
                 }
             }

--- a/src/samplers/nvidia/config.rs
+++ b/src/samplers/nvidia/config.rs
@@ -1,0 +1,137 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use nvml_wrapper::NVML;
+use rustcommon_atomics::*;
+use serde_derive::Deserialize;
+use strum::IntoEnumIterator;
+
+use crate::config::SamplerConfig;
+
+use super::stat::*;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NvidiaConfig {
+    #[serde(default)]
+    enabled: AtomicBool,
+    #[serde(default)]
+    interval: Option<AtomicUsize>,
+    #[serde(default = "crate::common::default_percentiles")]
+    percentiles: Vec<f64>,
+    #[serde(default = "default_statistics")]
+    pub(crate) statistics: Vec<NvidiaConfigStatistic>,
+}
+
+impl Default for NvidiaConfig {
+    fn default() -> Self {
+        Self {
+            enabled: Default::default(),
+            interval: Default::default(),
+            percentiles: crate::common::default_percentiles(),
+            statistics: default_statistics(),
+        }
+    }
+}
+
+fn default_statistics() -> Vec<NvidiaConfigStatistic> {
+    NvidiaConfigStatistic::iter().collect()
+}
+
+impl SamplerConfig for NvidiaConfig {
+    type Statistic = NvidiaStatistic;
+    fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    fn interval(&self) -> Option<usize> {
+        self.interval.as_ref().map(|v| v.load(Ordering::Relaxed))
+    }
+
+    fn percentiles(&self) -> &[f64] {
+        &self.percentiles
+    }
+
+    fn statistics(&self) -> Vec<<Self as SamplerConfig>::Statistic> {
+        let mut enabled = Vec::new();
+        let nvml = NVML::builder().init().expect("failed to initialize nvml");
+        let devices = nvml.device_count().unwrap_or(0);
+        for statistic in self.statistics.iter() {
+            for id in 0..devices {
+                match statistic {
+                    NvidiaConfigStatistic::GpuTemperature => {
+                        enabled.push(NvidiaStatistic::GpuTemperature(id));
+                    }
+                    NvidiaConfigStatistic::GpuUtilization => {
+                        enabled.push(NvidiaStatistic::GpuUtilization(id));
+                    }
+                    NvidiaConfigStatistic::MemoryEccEnabled => {
+                        enabled.push(NvidiaStatistic::MemoryEccEnabled(id));
+                    }
+                    NvidiaConfigStatistic::MemoryEccSbe => {
+                        enabled.push(NvidiaStatistic::MemoryEccSbe(id));
+                    }
+                    NvidiaConfigStatistic::MemoryEccDbe => {
+                        enabled.push(NvidiaStatistic::MemoryEccDbe(id));
+                    }
+                    NvidiaConfigStatistic::MemoryUtilization => {
+                        enabled.push(NvidiaStatistic::MemoryUtilization(id));
+                    }
+                    NvidiaConfigStatistic::EncoderUtilization => {
+                        enabled.push(NvidiaStatistic::EncoderUtilization(id));
+                    }
+                    NvidiaConfigStatistic::DecoderUtilization => {
+                        enabled.push(NvidiaStatistic::DecoderUtilization(id));
+                    }
+                    NvidiaConfigStatistic::PowerUsage => {
+                        enabled.push(NvidiaStatistic::PowerUsage(id));
+                    }
+                    NvidiaConfigStatistic::PowerLimit => {
+                        enabled.push(NvidiaStatistic::PowerLimit(id));
+                    }
+                    NvidiaConfigStatistic::EnergyConsumption => {
+                        enabled.push(NvidiaStatistic::EnergyConsumption(id));
+                    }
+                    NvidiaConfigStatistic::ClockSMCurrent => {
+                        enabled.push(NvidiaStatistic::ClockSMCurrent(id));
+                    }
+                    NvidiaConfigStatistic::ClockMemoryCurrent => {
+                        enabled.push(NvidiaStatistic::ClockMemoryCurrent(id));
+                    }
+                    NvidiaConfigStatistic::PcieReplay => {
+                        enabled.push(NvidiaStatistic::PcieReplay(id));
+                    }
+                    NvidiaConfigStatistic::PcieRxThroughput => {
+                        enabled.push(NvidiaStatistic::PcieRxThroughput(id));
+                    }
+                    NvidiaConfigStatistic::PcieTxThroughput => {
+                        enabled.push(NvidiaStatistic::PcieTxThroughput(id));
+                    }
+                    NvidiaConfigStatistic::MemoryFbFree => {
+                        enabled.push(NvidiaStatistic::MemoryFbFree(id));
+                    }
+                    NvidiaConfigStatistic::MemoryFbTotal => {
+                        enabled.push(NvidiaStatistic::MemoryFbTotal(id));
+                    }
+                    NvidiaConfigStatistic::MemoryFbUsed => {
+                        enabled.push(NvidiaStatistic::MemoryFbUsed(id));
+                    }
+                    NvidiaConfigStatistic::MemoryRetiredSbe => {
+                        enabled.push(NvidiaStatistic::MemoryRetiredSbe(id));
+                    }
+                    NvidiaConfigStatistic::MemoryRetiredDbe => {
+                        enabled.push(NvidiaStatistic::MemoryRetiredDbe(id));
+                    }
+                    NvidiaConfigStatistic::MemoryRetiredPending => {
+                        enabled.push(NvidiaStatistic::MemoryRetiredPending(id));
+                    }
+                    NvidiaConfigStatistic::ProcessesCompute => {
+                        enabled.push(NvidiaStatistic::ProcessesCompute(id));
+                    }
+                }
+            }
+        }
+        enabled
+    }
+}

--- a/src/samplers/nvidia/mod.rs
+++ b/src/samplers/nvidia/mod.rs
@@ -1,0 +1,322 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use std::convert::TryInto;
+use std::time::*;
+
+use async_trait::async_trait;
+use nvml_wrapper::NVML;
+use nvml_wrapper::enum_wrappers::device::*;
+
+use crate::config::SamplerConfig;
+use crate::samplers::Common;
+use crate::Sampler;
+
+mod config;
+mod stat;
+
+pub use config::*;
+pub use stat::*;
+
+#[allow(dead_code)]
+pub struct Nvidia {
+    common: Common,
+    nvml: NVML,
+    statistics: Vec<NvidiaStatistic>,
+}
+
+#[async_trait]
+impl Sampler for Nvidia {
+    type Statistic = NvidiaStatistic;
+
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
+        let statistics = common.config().samplers().nvidia().statistics();
+        match NVML::builder().init() {
+            Ok(nvml) => {
+                #[allow(unused_mut)]
+                let mut sampler = Self { common, nvml, statistics };
+
+                if sampler.sampler_config().enabled() {
+                    sampler.register();
+                }
+
+                Ok(sampler)
+            }
+            Err(e) => Err(anyhow!("failed to initialize NVML: {}", e))
+        }
+    }
+
+    fn spawn(common: Common) {
+        debug!("spawning");
+        if common.config().samplers().nvidia().enabled() {
+            debug!("sampler is enabled");
+            if let Ok(mut sampler) = Nvidia::new(common.clone()) {
+                common.runtime().spawn(async move {
+                    loop {
+                        let _ = sampler.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize nvidia sampler");
+            } else {
+                error!("failed to initialize nvidia sampler");
+            }
+        }
+    }
+
+    fn common(&self) -> &Common {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut Common {
+        &mut self.common
+    }
+
+    fn sampler_config(&self) -> &dyn SamplerConfig<Statistic = Self::Statistic> {
+        self.common.config().samplers().nvidia()
+    }
+
+    async fn sample(&mut self) -> Result<(), std::io::Error> {
+        if let Some(ref mut delay) = self.delay() {
+            delay.tick().await;
+        }
+
+        if !self.sampler_config().enabled() {
+            return Ok(());
+        }
+
+        debug!("sampling");
+
+        let r = self.sample_nvml().await;
+        self.map_result(r)?;
+
+        Ok(())
+    }
+}
+
+impl Nvidia {
+    async fn sample_nvml(&mut self) -> Result<(), std::io::Error> {
+        let time = Instant::now();
+        let devices = self.nvml.device_count().unwrap_or(0);
+        let statistics = &self.common.config().samplers().nvidia().statistics;
+        for id in 0..devices {
+            if let Ok(device) = self.nvml.device_by_index(id) {
+                for statistic in statistics {
+                    match statistic {
+                        NvidiaConfigStatistic::GpuTemperature => {
+                            if let Ok(value) = device.temperature(TemperatureSensor::Gpu) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::GpuTemperature(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryEccEnabled => {
+                            if let Ok(value) = device.is_ecc_enabled().map(|v| if v.currently_enabled { 1_u32 } else { 0_u32 }) {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::MemoryEccEnabled(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryEccSbe => {
+                            if let Ok(value) = device.total_ecc_errors(MemoryError::Corrected, EccCounter::Aggregate) {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::MemoryEccSbe(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryEccDbe => {
+                            if let Ok(value) = device.total_ecc_errors(MemoryError::Uncorrected, EccCounter::Aggregate) {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::MemoryEccDbe(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::PowerUsage => {
+                            if let Ok(value) = device.power_usage() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::PowerUsage(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::PowerLimit => {
+                            if let Ok(value) = device.enforced_power_limit() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::PowerLimit(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::EnergyConsumption => {
+                            if let Ok(value) = device.total_energy_consumption() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::EnergyConsumption(id),
+                                    time,
+                                    value,
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::ClockSMCurrent => {
+                            if let Ok(value) = device.clock(Clock::SM, ClockId::Current) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::ClockSMCurrent(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::ClockMemoryCurrent => {
+                            if let Ok(value) = device.clock(Clock::Memory, ClockId::Current) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::ClockMemoryCurrent(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::PcieReplay => {
+                            if let Ok(value) = device.pcie_replay_counter() {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::PcieReplay(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::PcieRxThroughput => {
+                            if let Ok(value) = device.pcie_throughput(PcieUtilCounter::Receive) {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::PcieRxThroughput(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::PcieTxThroughput => {
+                            if let Ok(value) = device.pcie_throughput(PcieUtilCounter::Send) {
+                                let _ = self.metrics().record_counter(
+                                    &NvidiaStatistic::PcieTxThroughput(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::GpuUtilization => {
+                            if let Ok(value) = device.utilization_rates() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::GpuUtilization(id),
+                                    time,
+                                    value.gpu.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryUtilization => {
+                            if let Ok(value) = device.utilization_rates() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryUtilization(id),
+                                    time,
+                                    value.memory.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::DecoderUtilization => {
+                            if let Ok(value) = device.decoder_utilization() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::DecoderUtilization(id),
+                                    time,
+                                    value.utilization as u64 * 100_u64 / value.sampling_period as u64,
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::EncoderUtilization => {
+                            if let Ok(value) = device.encoder_utilization() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::EncoderUtilization(id),
+                                    time,
+                                    value.utilization as u64 * 100_u64 / value.sampling_period as u64,
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryFbFree => {
+                            if let Ok(value) = device.memory_info() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryFbFree(id),
+                                    time,
+                                    value.free.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryFbTotal => {
+                            if let Ok(value) = device.memory_info() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryFbTotal(id),
+                                    time,
+                                    value.total.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryFbUsed => {
+                            if let Ok(value) = device.memory_info() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryFbUsed(id),
+                                    time,
+                                    value.used.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredSbe => {
+                            if let Ok(value) = device.retired_pages(RetirementCause::MultipleSingleBitEccErrors) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryRetiredSbe(id),
+                                    time,
+                                    value.len().try_into().unwrap(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredDbe => {
+                            if let Ok(value) = device.retired_pages(RetirementCause::DoubleBitEccError) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryRetiredDbe(id),
+                                    time,
+                                    value.len().try_into().unwrap(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::MemoryRetiredPending => {
+                            if let Ok(value) = device.are_pages_pending_retired().map(|v| if v { 1_u32 } else { 0_u32 }) {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::MemoryRetiredDbe(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                        NvidiaConfigStatistic::ProcessesCompute => {
+                            if let Ok(value) = device.running_compute_processes_count() {
+                                let _ = self.metrics().record_gauge(
+                                    &NvidiaStatistic::ProcessesCompute(id),
+                                    time,
+                                    value.into(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        Ok(())
+    }
+}
+

--- a/src/samplers/nvidia/mod.rs
+++ b/src/samplers/nvidia/mod.rs
@@ -6,8 +6,8 @@ use std::convert::TryInto;
 use std::time::*;
 
 use async_trait::async_trait;
-use nvml_wrapper::NVML;
 use nvml_wrapper::enum_wrappers::device::*;
+use nvml_wrapper::NVML;
 
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
@@ -35,7 +35,11 @@ impl Sampler for Nvidia {
         match NVML::builder().init() {
             Ok(nvml) => {
                 #[allow(unused_mut)]
-                let mut sampler = Self { common, nvml, statistics };
+                let mut sampler = Self {
+                    common,
+                    nvml,
+                    statistics,
+                };
 
                 if sampler.sampler_config().enabled() {
                     sampler.register();
@@ -43,7 +47,7 @@ impl Sampler for Nvidia {
 
                 Ok(sampler)
             }
-            Err(e) => Err(anyhow!("failed to initialize NVML: {}", e))
+            Err(e) => Err(anyhow!("failed to initialize NVML: {}", e)),
         }
     }
 
@@ -114,7 +118,13 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryEccEnabled => {
-                            if let Ok(value) = device.is_ecc_enabled().map(|v| if v.currently_enabled { 1_u32 } else { 0_u32 }) {
+                            if let Ok(value) = device.is_ecc_enabled().map(|v| {
+                                if v.currently_enabled {
+                                    1_u32
+                                } else {
+                                    0_u32
+                                }
+                            }) {
                                 let _ = self.metrics().record_counter(
                                     &NvidiaStatistic::MemoryEccEnabled(id),
                                     time,
@@ -123,7 +133,9 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryEccSbe => {
-                            if let Ok(value) = device.total_ecc_errors(MemoryError::Corrected, EccCounter::Aggregate) {
+                            if let Ok(value) = device
+                                .total_ecc_errors(MemoryError::Corrected, EccCounter::Aggregate)
+                            {
                                 let _ = self.metrics().record_counter(
                                     &NvidiaStatistic::MemoryEccSbe(id),
                                     time,
@@ -132,7 +144,9 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryEccDbe => {
-                            if let Ok(value) = device.total_ecc_errors(MemoryError::Uncorrected, EccCounter::Aggregate) {
+                            if let Ok(value) = device
+                                .total_ecc_errors(MemoryError::Uncorrected, EccCounter::Aggregate)
+                            {
                                 let _ = self.metrics().record_counter(
                                     &NvidiaStatistic::MemoryEccDbe(id),
                                     time,
@@ -235,7 +249,8 @@ impl Nvidia {
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::DecoderUtilization(id),
                                     time,
-                                    value.utilization as u64 * 100_u64 / value.sampling_period as u64,
+                                    value.utilization as u64 * 100_u64
+                                        / value.sampling_period as u64,
                                 );
                             }
                         }
@@ -244,7 +259,8 @@ impl Nvidia {
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::EncoderUtilization(id),
                                     time,
-                                    value.utilization as u64 * 100_u64 / value.sampling_period as u64,
+                                    value.utilization as u64 * 100_u64
+                                        / value.sampling_period as u64,
                                 );
                             }
                         }
@@ -276,7 +292,9 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryRetiredSbe => {
-                            if let Ok(value) = device.retired_pages(RetirementCause::MultipleSingleBitEccErrors) {
+                            if let Ok(value) =
+                                device.retired_pages(RetirementCause::MultipleSingleBitEccErrors)
+                            {
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::MemoryRetiredSbe(id),
                                     time,
@@ -285,7 +303,9 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryRetiredDbe => {
-                            if let Ok(value) = device.retired_pages(RetirementCause::DoubleBitEccError) {
+                            if let Ok(value) =
+                                device.retired_pages(RetirementCause::DoubleBitEccError)
+                            {
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::MemoryRetiredDbe(id),
                                     time,
@@ -294,7 +314,13 @@ impl Nvidia {
                             }
                         }
                         NvidiaConfigStatistic::MemoryRetiredPending => {
-                            if let Ok(value) = device.are_pages_pending_retired().map(|v| if v { 1_u32 } else { 0_u32 }) {
+                            if let Ok(value) = device.are_pages_pending_retired().map(|v| {
+                                if v {
+                                    1_u32
+                                } else {
+                                    0_u32
+                                }
+                            }) {
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::MemoryRetiredDbe(id),
                                     time,
@@ -315,8 +341,7 @@ impl Nvidia {
                 }
             }
         }
-        
+
         Ok(())
     }
 }
-

--- a/src/samplers/nvidia/stat.rs
+++ b/src/samplers/nvidia/stat.rs
@@ -1,0 +1,251 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use core::convert::TryFrom;
+use core::str::FromStr;
+
+use rustcommon_metrics::*;
+use serde_derive::{Deserialize, Serialize};
+use strum::ParseError;
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    PartialEq,
+    Hash,
+    Serialize,
+)]
+#[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
+pub enum NvidiaConfigStatistic {
+    #[strum(serialize = "gpu/temperature")]
+    GpuTemperature,
+    #[strum(serialize = "memory/ecc/sbe")]
+    MemoryEccSbe,
+    #[strum(serialize = "memory/ecc/dbe")]
+    MemoryEccDbe,
+    #[strum(serialize = "memory/ecc/enabled")]
+    MemoryEccEnabled,
+    #[strum(serialize = "power/usage")]
+    PowerUsage,
+    #[strum(serialize = "power/limit")]
+    PowerLimit,
+    #[strum(serialize = "energy/consumption")]
+    EnergyConsumption,
+    #[strum(serialize = "clock/sm/current")]
+    ClockSMCurrent,
+    #[strum(serialize = "clock/memory/current")]
+    ClockMemoryCurrent,
+    #[strum(serialize = "pcie/replay")]
+    PcieReplay,
+    #[strum(serialize = "pcie/rx/throughput")]
+    PcieRxThroughput,
+    #[strum(serialize = "pcie/tx/throughput")]
+    PcieTxThroughput,
+    #[strum(serialize = "gpu/utilization")]
+    GpuUtilization,
+    #[strum(serialize = "memory/utilization")]
+    MemoryUtilization,
+    #[strum(serialize = "decoder/utilization")]
+    DecoderUtilization,
+    #[strum(serialize = "encoder/utilization")]
+    EncoderUtilization,
+    #[strum(serialize = "memory/fb/free")]
+    MemoryFbFree,
+    #[strum(serialize = "memory/fb/total")]
+    MemoryFbTotal,
+    #[strum(serialize = "memory/fb/used")]
+    MemoryFbUsed,
+    #[strum(serialize = "memory/retired/sbe")]
+    MemoryRetiredSbe,
+    #[strum(serialize = "memory/retired/dbe")]
+    MemoryRetiredDbe,
+    #[strum(serialize = "memory/retired/pending")]
+    MemoryRetiredPending,
+    #[strum(serialize = "processes/compute")]
+    ProcessesCompute
+}
+
+impl TryFrom<&str> for NvidiaConfigStatistic {
+    type Error = ParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        NvidiaConfigStatistic::from_str(s)
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Hash,
+)]
+pub enum NvidiaStatistic {
+    GpuTemperature(u32),
+    MemoryEccSbe(u32),
+    MemoryEccDbe(u32),
+    MemoryEccEnabled(u32),
+    PowerUsage(u32),
+    PowerLimit(u32),
+    EnergyConsumption(u32),
+    ClockSMCurrent(u32),
+    ClockMemoryCurrent(u32),
+    PcieReplay(u32),
+    PcieRxThroughput(u32),
+    PcieTxThroughput(u32),
+    GpuUtilization(u32),
+    MemoryUtilization(u32),
+    DecoderUtilization(u32),
+    EncoderUtilization(u32),
+    MemoryFbFree(u32),
+    MemoryFbTotal(u32),
+    MemoryFbUsed(u32),
+    MemoryRetiredSbe(u32),
+    MemoryRetiredDbe(u32),
+    MemoryRetiredPending(u32),
+    ProcessesCompute(u32),
+}
+
+impl Statistic<AtomicU64, AtomicU32> for NvidiaStatistic {
+    // TODO(bmartin): this should be cleaned up once we have scoped metrics
+    fn name(&self) -> &str {
+        match self {
+            NvidiaStatistic::GpuTemperature(id) => match id {
+                0 => "nvidia/gpu_0/gpu/temperature",
+                1 => "nvidia/gpu_1/gpu/temperature",
+                _ => "nvidia/gpu_unknown/gpu/temperature",
+            }
+            NvidiaStatistic::MemoryEccEnabled(id) => match id {
+                0 => "nvidia/gpu_0/memory/ecc/enabled",
+                1 => "nvidia/gpu_1/memory/ecc/enabled",
+                _ => "nvidia/gpu_unknown/memory/ecc/enabled",
+            }
+            NvidiaStatistic::MemoryEccSbe(id) => match id {
+                0 => "nvidia/gpu_0/memory/ecc/sbe",
+                1 => "nvidia/gpu_1/memory/ecc/sbe",
+                _ => "nvidia/gpu_unknown/memory/ecc/sbe",
+            }
+            NvidiaStatistic::MemoryEccDbe(id) => match id {
+                0 => "nvidia/gpu_0/memory/ecc/dbe",
+                1 => "nvidia/gpu_1/memory/ecc/dbe",
+                _ => "nvidia/gpu_unknown/memory/ecc/dbe",
+            }
+            NvidiaStatistic::PowerUsage(id) => match id {
+                0 => "nvidia/gpu_0/power/usage",
+                1 => "nvidia/gpu_1/power/usage",
+                _ => "nvidia/gpu_unknown/power/usage",
+            }
+            NvidiaStatistic::PowerLimit(id) => match id {
+                0 => "nvidia/gpu_0/power/limit",
+                1 => "nvidia/gpu_1/power/limit",
+                _ => "nvidia/gpu_unknown/power/limit",
+            }
+            NvidiaStatistic::EnergyConsumption(id) => match id {
+                0 => "nvidia/gpu_0/energy/consumption",
+                1 => "nvidia/gpu_1/energy/consumption",
+                _ => "nvidia/gpu_unknown/energy/consumption",
+            }
+            NvidiaStatistic::ClockSMCurrent(id) => match id {
+                0 => "nvidia/gpu_0/clock/sm/current",
+                1 => "nvidia/gpu_1/clock/sm/current",
+                _ => "nvidia/gpu_unknown/clock/sm/current",
+            }
+            NvidiaStatistic::ClockMemoryCurrent(id) => match id {
+                0 => "nvidia/gpu_0/clock/memory/current",
+                1 => "nvidia/gpu_1/clock/memory/current",
+                _ => "nvidia/gpu_unknown/clock/memory/current",
+            }
+            NvidiaStatistic::PcieReplay(id) => match id {
+                0 => "nvidia/gpu_0/pcie/replay",
+                1 => "nvidia/gpu_1/pcie/replay",
+                _ => "nvidia/gpu_unknown/pcie/replay",
+            }
+            NvidiaStatistic::PcieRxThroughput(id) => match id {
+                0 => "nvidia/gpu_0/pcie/rx/throughput",
+                1 => "nvidia/gpu_1/pcie/rx/throughput",
+                _ => "nvidia/gpu_unknown/pcie/rx/throughput",
+            }
+            NvidiaStatistic::PcieTxThroughput(id) => match id {
+                0 => "nvidia/gpu_0/pcie/tx/throughput",
+                1 => "nvidia/gpu_1/pcie/tx/throughput",
+                _ => "nvidia/gpu_unknown/pcie/tx/throughput",
+            }
+            NvidiaStatistic::GpuUtilization(id) => match id {
+                0 => "nvidia/gpu_0/gpu/utilization",
+                1 => "nvidia/gpu_1/gpu/utilization",
+                _ => "nvidia/gpu_unknown/gpu/utilization",
+            }
+            NvidiaStatistic::MemoryUtilization(id) => match id {
+                0 => "nvidia/gpu_0/memory/utilization",
+                1 => "nvidia/gpu_1/memory/utilization",
+                _ => "nvidia/gpu_unknown/memory/utilization",
+            }
+            NvidiaStatistic::DecoderUtilization(id) => match id {
+                0 => "nvidia/gpu_0/decoder/utilization",
+                1 => "nvidia/gpu_1/decoder/utilization",
+                _ => "nvidia/gpu_unknown/decoder/utilization",
+            }
+            NvidiaStatistic::EncoderUtilization(id) => match id {
+                0 => "nvidia/gpu_0/encoder/utilization",
+                1 => "nvidia/gpu_1/encoder/utilization",
+                _ => "nvidia/gpu_unknown/encoder/utilization",
+            }
+            NvidiaStatistic::MemoryFbFree(id) => match id {
+                0 => "nvidia/gpu_0/memory/fb/free",
+                1 => "nvidia/gpu_1/memory/fb/free",
+                _ => "nvidia/gpu_unknown/memory/fb/free",
+            }
+            NvidiaStatistic::MemoryFbTotal(id) => match id {
+                0 => "nvidia/gpu_0/memory/fb/total",
+                1 => "nvidia/gpu_1/memory/fb/total",
+                _ => "nvidia/gpu_unknown/memory/fb/total",
+            }
+            NvidiaStatistic::MemoryFbUsed(id) => match id {
+                0 => "nvidia/gpu_0/memory/fb/used",
+                1 => "nvidia/gpu_1/memory/fb/used",
+                _ => "nvidia/gpu_unknown/memory/fb/used",
+            }
+            NvidiaStatistic::MemoryRetiredSbe(id) => match id {
+                0 => "nvidia/gpu_0/memory/retired/sbe",
+                1 => "nvidia/gpu_1/memory/retired/sbe",
+                _ => "nvidia/gpu_unknown/memory/retired/sbe",
+            }
+            NvidiaStatistic::MemoryRetiredDbe(id) => match id {
+                0 => "nvidia/gpu_0/memory/retired/dbe",
+                1 => "nvidia/gpu_1/memory/retired/dbe",
+                _ => "nvidia/gpu_unknown/memory/retired/dbe",
+            }
+            NvidiaStatistic::MemoryRetiredPending(id) => match id {
+                0 => "nvidia/gpu_0/memory/retired/pending",
+                1 => "nvidia/gpu_1/memory/retired/pending",
+                _ => "nvidia/gpu_unknown/memory/retired/pending",
+            }
+            NvidiaStatistic::ProcessesCompute(id) => match id {
+                0 => "nvidia/gpu_0/processes/compute",
+                1 => "nvidia/gpu_1/processes/compute",
+                _ => "nvidia/gpu_unknown/processes/compute",
+            }
+        }
+    }
+
+    fn source(&self) -> Source {
+        match self {
+            Self::MemoryEccSbe(_) | 
+            Self::MemoryEccDbe(_) | 
+            Self::EnergyConsumption(_) |
+            Self::MemoryRetiredDbe(_) |
+            Self::MemoryRetiredSbe(_) |
+            Self::PcieReplay(_) => Source::Counter,
+            _ => Source::Gauge
+        }
+    }
+}

--- a/src/samplers/nvidia/stat.rs
+++ b/src/samplers/nvidia/stat.rs
@@ -70,7 +70,7 @@ pub enum NvidiaConfigStatistic {
     #[strum(serialize = "memory/retired/pending")]
     MemoryRetiredPending,
     #[strum(serialize = "processes/compute")]
-    ProcessesCompute
+    ProcessesCompute,
 }
 
 impl TryFrom<&str> for NvidiaConfigStatistic {
@@ -81,14 +81,7 @@ impl TryFrom<&str> for NvidiaConfigStatistic {
     }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    PartialEq,
-    Hash,
-)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum NvidiaStatistic {
     GpuTemperature(u32),
     MemoryEccSbe(u32),
@@ -123,129 +116,129 @@ impl Statistic<AtomicU64, AtomicU32> for NvidiaStatistic {
                 0 => "nvidia/gpu_0/gpu/temperature",
                 1 => "nvidia/gpu_1/gpu/temperature",
                 _ => "nvidia/gpu_unknown/gpu/temperature",
-            }
+            },
             NvidiaStatistic::MemoryEccEnabled(id) => match id {
                 0 => "nvidia/gpu_0/memory/ecc/enabled",
                 1 => "nvidia/gpu_1/memory/ecc/enabled",
                 _ => "nvidia/gpu_unknown/memory/ecc/enabled",
-            }
+            },
             NvidiaStatistic::MemoryEccSbe(id) => match id {
                 0 => "nvidia/gpu_0/memory/ecc/sbe",
                 1 => "nvidia/gpu_1/memory/ecc/sbe",
                 _ => "nvidia/gpu_unknown/memory/ecc/sbe",
-            }
+            },
             NvidiaStatistic::MemoryEccDbe(id) => match id {
                 0 => "nvidia/gpu_0/memory/ecc/dbe",
                 1 => "nvidia/gpu_1/memory/ecc/dbe",
                 _ => "nvidia/gpu_unknown/memory/ecc/dbe",
-            }
+            },
             NvidiaStatistic::PowerUsage(id) => match id {
                 0 => "nvidia/gpu_0/power/usage",
                 1 => "nvidia/gpu_1/power/usage",
                 _ => "nvidia/gpu_unknown/power/usage",
-            }
+            },
             NvidiaStatistic::PowerLimit(id) => match id {
                 0 => "nvidia/gpu_0/power/limit",
                 1 => "nvidia/gpu_1/power/limit",
                 _ => "nvidia/gpu_unknown/power/limit",
-            }
+            },
             NvidiaStatistic::EnergyConsumption(id) => match id {
                 0 => "nvidia/gpu_0/energy/consumption",
                 1 => "nvidia/gpu_1/energy/consumption",
                 _ => "nvidia/gpu_unknown/energy/consumption",
-            }
+            },
             NvidiaStatistic::ClockSMCurrent(id) => match id {
                 0 => "nvidia/gpu_0/clock/sm/current",
                 1 => "nvidia/gpu_1/clock/sm/current",
                 _ => "nvidia/gpu_unknown/clock/sm/current",
-            }
+            },
             NvidiaStatistic::ClockMemoryCurrent(id) => match id {
                 0 => "nvidia/gpu_0/clock/memory/current",
                 1 => "nvidia/gpu_1/clock/memory/current",
                 _ => "nvidia/gpu_unknown/clock/memory/current",
-            }
+            },
             NvidiaStatistic::PcieReplay(id) => match id {
                 0 => "nvidia/gpu_0/pcie/replay",
                 1 => "nvidia/gpu_1/pcie/replay",
                 _ => "nvidia/gpu_unknown/pcie/replay",
-            }
+            },
             NvidiaStatistic::PcieRxThroughput(id) => match id {
                 0 => "nvidia/gpu_0/pcie/rx/throughput",
                 1 => "nvidia/gpu_1/pcie/rx/throughput",
                 _ => "nvidia/gpu_unknown/pcie/rx/throughput",
-            }
+            },
             NvidiaStatistic::PcieTxThroughput(id) => match id {
                 0 => "nvidia/gpu_0/pcie/tx/throughput",
                 1 => "nvidia/gpu_1/pcie/tx/throughput",
                 _ => "nvidia/gpu_unknown/pcie/tx/throughput",
-            }
+            },
             NvidiaStatistic::GpuUtilization(id) => match id {
                 0 => "nvidia/gpu_0/gpu/utilization",
                 1 => "nvidia/gpu_1/gpu/utilization",
                 _ => "nvidia/gpu_unknown/gpu/utilization",
-            }
+            },
             NvidiaStatistic::MemoryUtilization(id) => match id {
                 0 => "nvidia/gpu_0/memory/utilization",
                 1 => "nvidia/gpu_1/memory/utilization",
                 _ => "nvidia/gpu_unknown/memory/utilization",
-            }
+            },
             NvidiaStatistic::DecoderUtilization(id) => match id {
                 0 => "nvidia/gpu_0/decoder/utilization",
                 1 => "nvidia/gpu_1/decoder/utilization",
                 _ => "nvidia/gpu_unknown/decoder/utilization",
-            }
+            },
             NvidiaStatistic::EncoderUtilization(id) => match id {
                 0 => "nvidia/gpu_0/encoder/utilization",
                 1 => "nvidia/gpu_1/encoder/utilization",
                 _ => "nvidia/gpu_unknown/encoder/utilization",
-            }
+            },
             NvidiaStatistic::MemoryFbFree(id) => match id {
                 0 => "nvidia/gpu_0/memory/fb/free",
                 1 => "nvidia/gpu_1/memory/fb/free",
                 _ => "nvidia/gpu_unknown/memory/fb/free",
-            }
+            },
             NvidiaStatistic::MemoryFbTotal(id) => match id {
                 0 => "nvidia/gpu_0/memory/fb/total",
                 1 => "nvidia/gpu_1/memory/fb/total",
                 _ => "nvidia/gpu_unknown/memory/fb/total",
-            }
+            },
             NvidiaStatistic::MemoryFbUsed(id) => match id {
                 0 => "nvidia/gpu_0/memory/fb/used",
                 1 => "nvidia/gpu_1/memory/fb/used",
                 _ => "nvidia/gpu_unknown/memory/fb/used",
-            }
+            },
             NvidiaStatistic::MemoryRetiredSbe(id) => match id {
                 0 => "nvidia/gpu_0/memory/retired/sbe",
                 1 => "nvidia/gpu_1/memory/retired/sbe",
                 _ => "nvidia/gpu_unknown/memory/retired/sbe",
-            }
+            },
             NvidiaStatistic::MemoryRetiredDbe(id) => match id {
                 0 => "nvidia/gpu_0/memory/retired/dbe",
                 1 => "nvidia/gpu_1/memory/retired/dbe",
                 _ => "nvidia/gpu_unknown/memory/retired/dbe",
-            }
+            },
             NvidiaStatistic::MemoryRetiredPending(id) => match id {
                 0 => "nvidia/gpu_0/memory/retired/pending",
                 1 => "nvidia/gpu_1/memory/retired/pending",
                 _ => "nvidia/gpu_unknown/memory/retired/pending",
-            }
+            },
             NvidiaStatistic::ProcessesCompute(id) => match id {
                 0 => "nvidia/gpu_0/processes/compute",
                 1 => "nvidia/gpu_1/processes/compute",
                 _ => "nvidia/gpu_unknown/processes/compute",
-            }
+            },
         }
     }
 
     fn source(&self) -> Source {
         match self {
-            Self::MemoryEccSbe(_) | 
-            Self::MemoryEccDbe(_) | 
-            Self::EnergyConsumption(_) |
-            Self::MemoryRetiredDbe(_) |
-            Self::MemoryRetiredSbe(_) |
-            Self::PcieReplay(_) => Source::Counter,
-            _ => Source::Gauge
+            Self::MemoryEccSbe(_)
+            | Self::MemoryEccDbe(_)
+            | Self::EnergyConsumption(_)
+            | Self::MemoryRetiredDbe(_)
+            | Self::MemoryRetiredSbe(_)
+            | Self::PcieReplay(_) => Source::Counter,
+            _ => Source::Gauge,
         }
     }
 }


### PR DESCRIPTION
Adds Nvidia GPU sampler to gather telemetry about GPU utilization
and health metrics.
