### PR TITLE
nvidia: change power and energy units

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -341,7 +341,7 @@ metrics to collect uses the short form of the metric name, as provided below.
 * `clock/memory/current` - current memory clock speed in MHz
 * `decoder/utilization` - video decoder utilization as a percentage
 * `encoder/utilization` - video encoder utilization as a percentage
-* `energy/consumption` - total energy consumption since boot in mJ
+* `energy/consumption` - total energy consumption since boot in Joules
 * `gpu/temperature` - current GPU temperature in °C
 * `cpu/utilization` - GPU utilzation as a percentage
 * `memory/ecc/enabled` - boolean (0 or 1) indicating if ECC is enabled
@@ -358,8 +358,8 @@ metrics to collect uses the short form of the metric name, as provided below.
 * `pcie/replay` - count of PCIe replays. May indicate link issues.
 * `pcie/rx/throughput` - PCIe receive throughput in KB/s
 * `pcie/tx/throughput` - PCIe transmit throughput in KB/s
-* `power/limit` - enforced power limit in mW
-* `power/usage` - current power usage in mW
+* `power/limit` - enforced power limit in Watts
+* `power/usage` - current power usage in Watts
 * `processes/compute` - number of processes running in compute context
 
 ## Page Cache

--- a/src/samplers/nvidia/mod.rs
+++ b/src/samplers/nvidia/mod.rs
@@ -156,24 +156,27 @@ impl Nvidia {
                         }
                         NvidiaConfigStatistic::PowerUsage => {
                             if let Ok(value) = device.power_usage() {
+                                let value = (value as f64 / 1000.0).round() as u64;
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::PowerUsage(id),
                                     time,
-                                    value.into(),
+                                    value,
                                 );
                             }
                         }
                         NvidiaConfigStatistic::PowerLimit => {
                             if let Ok(value) = device.enforced_power_limit() {
+                                let value = (value as f64 / 1000.0).round() as u64;
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::PowerLimit(id),
                                     time,
-                                    value.into(),
+                                    value,
                                 );
                             }
                         }
                         NvidiaConfigStatistic::EnergyConsumption => {
                             if let Ok(value) = device.total_energy_consumption() {
+                                let value = (value as f64 / 1000.0).round() as u64;
                                 let _ = self.metrics().record_gauge(
                                     &NvidiaStatistic::EnergyConsumption(id),
                                     time,


### PR DESCRIPTION
Fixes #207 by changing nvidia sampler power and energy units to
Watts and Joules respectively.
