### PR TITLE
bugfix: http and memcache samplers report incorrect percentiles

### DIFF
--- a/src/samplers/http/mod.rs
+++ b/src/samplers/http/mod.rs
@@ -112,7 +112,7 @@ impl Sampler for Http {
                                 self.common().metrics().register(statistic);
                                 self.common()
                                     .metrics()
-                                    .set_summary(statistic, Summary::stream(self.samples()));
+                                    .add_summary(statistic, Summary::stream(self.samples()));
                                 if self.passthrough {
                                     self.common()
                                         .metrics()

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -131,7 +131,7 @@ impl Sampler for Memcache {
                                         // these select metrics get histogram summaries and
                                         // percentile output
                                         self.common().metrics().register(&statistic);
-                                        self.common().metrics().set_summary(
+                                        self.common().metrics().add_summary(
                                             &statistic,
                                             Summary::stream(self.samples()),
                                         );

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -105,7 +105,7 @@ pub trait Sampler: Sized + Send {
             let percentiles = self.sampler_config().percentiles();
             if !percentiles.is_empty() {
                 if statistic.source() == Source::Distribution {
-                    self.common().metrics().set_summary(
+                    self.common().metrics().add_summary(
                         &statistic,
                         Summary::heatmap(
                             1_000_000_000,


### PR DESCRIPTION
In #167 the metrics library was updated to a newer version. As part
of this change, we began using the 'set_summary()` function to make
sure the stream stats were initialized.

Unfortunately, we should have used `add_summary()`.

With `set_summary()`, the existing summary is overwritten. This was
resulting in the summary data being lost. This was not caught
earlier as it only applies to the HTTP and Memcache samplers which
call `set_summary()` during `sample()`, where the other stats have
this called once during sampler initialization.

Changes the calls to `set_summary()` to `add_summary()` everywhere
for safety.

Tested locally, this fixes the HTTP sampler and it now produces
proper percentiles. The same change would apply to the memcache
sampler.
