### PR TITLE
fix build issue for NTP sampler under musl toolchain

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -214,8 +214,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: install rust musl toolchain
         run: rustup target add x86_64-unknown-linux-musl
+      - name: update apt
+        run: sudo apt-get update
       - name: install musl-gcc
-        run: apt-get install -y musl-gcc
+        run: sudo apt-get install -y musl-gcc
       - name: build
         run: cargo build --release --target x86_64-unknown-linux-musl
   rustfmt:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -207,6 +207,15 @@ jobs:
         run: cargo build --release
       - name: Smoketest
         run: target/release/rezolus --config configs/macos.toml & sleep 180; curl -s http://localhost:4242/vars
+  musl:
+    name: musl
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: install toolchain
+        run: rustup target add x86_64-unknown-linux-musl
+      - name: build
+        run: cargo build --release --target x86_64-unknown-linux-musl
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -212,8 +212,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: install toolchain
+      - name: install rust musl toolchain
         run: rustup target add x86_64-unknown-linux-musl
+      - name: install musl-gcc
+        run: apt-get install -y musl-gcc
       - name: build
         run: cargo build --release --target x86_64-unknown-linux-musl
   rustfmt:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -216,8 +216,8 @@ jobs:
         run: rustup target add x86_64-unknown-linux-musl
       - name: update apt
         run: sudo apt-get update
-      - name: install musl-gcc
-        run: sudo apt-get install -y musl-gcc
+      - name: install musl-tools
+        run: sudo apt-get install -y musl-tools
       - name: build
         run: cargo build --release --target x86_64-unknown-linux-musl
   rustfmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.15.0+1.1.1k"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1092,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1368,6 +1378,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "nvml-wrapper",
+ "openssl",
  "regex",
  "reqwest",
  "rustcommon-atomics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ num = "0.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 nvml-wrapper = "0.7.0"
+openssl = { version = "0.10.33", features = ["vendored"] }
 regex = "1.4.6"
 reqwest = { version = "0.11.3", features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -327,6 +327,18 @@ Provides system-wide network telemetry
 * `network/receive/size` - size distribution, in bytes, of received packets
 * `network/transmit/size` - size distribution, in bytes, of transmitted packets
 
+## NTP
+
+NTP sampler provides some basic stats about time synchronization via NTP.
+
+**NOTE:** this sampler is currently not supported for musl toolchains
+
+### Basic
+
+* `ntp/estimated_error` - the current estimated error of the local clock in
+  nanoseconds
+* `ntp/maximum_error` - the maximum error of the local clock in nanoseconds
+
 ## Nvidia
 
 Telemetry for Nvidia GPUs, collected by using the Nvidia Management Library

--- a/src/samplers/ntp/mod.rs
+++ b/src/samplers/ntp/mod.rs
@@ -88,6 +88,7 @@ impl Sampler for Ntp {
 }
 
 impl Ntp {
+    #[cfg(not(target_env = "musl"))]
     async fn sample_ntp_adjtime(&mut self) -> Result<(), std::io::Error> {
         let mut timeval = default_ntptimeval();
         let time = Instant::now();
@@ -108,6 +109,12 @@ impl Ntp {
         }
         Ok(())
     }
+
+    #[cfg(target_env = "musl")]
+    async fn sample_ntp_adjtime(&mut self) -> Result<(), std::io::Error> {
+        // TODO: implement NTP sampling for musl
+        Ok(())
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -124,7 +131,7 @@ fn default_ntptimeval() -> libc::ntptimeval {
     }
 }
 
-#[cfg(all(not(target_os = "macos"), not(target_os = "ios"), unix))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_env = "musl"), unix))]
 fn default_ntptimeval() -> libc::ntptimeval {
     libc::ntptimeval {
         time: libc::timeval {

--- a/src/samplers/ntp/mod.rs
+++ b/src/samplers/ntp/mod.rs
@@ -131,7 +131,12 @@ fn default_ntptimeval() -> libc::ntptimeval {
     }
 }
 
-#[cfg(all(not(target_os = "macos"), not(target_os = "ios"), not(target_env = "musl"), unix))]
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_env = "musl"),
+    unix
+))]
 fn default_ntptimeval() -> libc::ntptimeval {
     libc::ntptimeval {
         time: libc::timeval {


### PR DESCRIPTION
The NTP sampler uses some libc functions which are present in
glibc but not in musl libc. This causes the build to fail under
Alpine as reported in #216

Fixes the build issue by specializing the NTP sampler using
conditional compilation for the target env. Currently, this means
that the NTP sampling is a no-op for musl targets.

Adds a simple build-only CI pass for a musl target, which is
appropriate given that the musl target is tier 2 for Rust, meaning
it is only guaranteed to build and may not product a working
build.

Rezolus should now build for musl target.
