### PR TITLE
disable TCP sampler BPF in CI

### DIFF
--- a/configs/ci.toml
+++ b/configs/ci.toml
@@ -52,7 +52,7 @@ perf_events = true
 enabled = true
 
 [samplers.tcp]
-bpf = true
+bpf = false
 enabled = true
 
 [samplers.udp]


### PR DESCRIPTION
Disable the BPF for the TCP sampler in CI due to some issues with
some combinations of older BCC versions and newer kernel versions
with llvm9.
