### PR TITLE
bugfix: interrupts sampler may fail to sample all interrupts

### DIFF
--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -172,7 +172,13 @@ impl Interrupt {
             let mut reader = BufReader::new(file);
             let mut line = String::new();
 
-            while reader.read_line(&mut line).await? > 0 {
+            loop {
+                line.clear();
+
+                if reader.read_line(&mut line).await? == 0 {
+                    break;
+                }
+
                 let parts: Vec<&str> = line.split_whitespace().collect();
                 if cores.is_none() {
                     cores = Some(parts.len());
@@ -281,7 +287,6 @@ impl Interrupt {
                 } else {
                     result.insert(InterruptStatistic::Node1Total, node1);
                 }
-                line.clear();
             }
         }
 


### PR DESCRIPTION
Reported in #224, the interrupts sampler can get tripped up by
lines which do not match the expected keywords. This is a result of
using a while loop with continue expression that bypass clearing
the line buffer.

This PR addresses this issue by reimplementing the loop so that we
can clear the line buffer at the start of the loop. This approach
allows us to ensure the line buffer is empty without requiring us
to remember to clear the buffer immediately before a continue.
