### PR TITLE
bugfix: memory sampler missing some metric

### DIFF
--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -115,7 +115,7 @@ impl Memory {
             let mut line = String::new();
 
             let re =
-                Regex::new(r"(?P<stat>\w+):\s+(?P<value>\d+)").expect("failed to compile regex");
+                Regex::new(r"(?P<stat>.+):\s+(?P<value>\d+)").expect("failed to compile regex");
 
             while reader.read_line(&mut line).await? > 0 {
                 if let Some(caps) = re.captures(&line) {


### PR DESCRIPTION
As reported in #224, memory sampler is not reporting stats for
`memory/active/anon`, `memory/inactive/anon`, due to an error in
the regex used to grab the statistic names from `/proc/meminfo`.

This PR fixes the issue by changing the character class used in the
regex.
