### PR TITLE
interrupts: remove interrupt/serial statistic

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -143,7 +143,6 @@ Provides system-wide telemetry for IRQs
 * `interrupt/rescheduling` - interrupts used to notify a core to schedule a
   thread
 * `interrupt/rtc` - interrupts caused by the realtime clock
-* `interrupt/serial` - interrupts caused by serial ports
 * `interrupt/spurious` - interrupts which were marked spurious and not handled
 * `interrupt/thermal_event` - interrupts caused by thermal events, like
   throttling

--- a/src/samplers/interrupt/stat.rs
+++ b/src/samplers/interrupt/stat.rs
@@ -53,8 +53,6 @@ pub enum InterruptStatistic {
     MachineCheckException,
     #[strum(serialize = "interrupt/rtc")]
     RealTimeClock,
-    #[strum(serialize = "interrupt/serial")]
-    Serial,
     #[strum(serialize = "interrupt/node0/total")]
     Node0Total,
     #[strum(serialize = "interrupt/node1/total")]


### PR DESCRIPTION
Removes the `interrupt/serial` statistic as it is not currently
collected.
