### PR TITLE
fix prometheus metrics exposition

### DIFF
--- a/src/exposition/mod.rs
+++ b/src/exposition/mod.rs
@@ -48,7 +48,10 @@ impl MetricsSnapshot {
                     data.push(format!("# TYPE {} gauge\n{} {}", label, label, value));
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("# TYPE {} gauge\n{}{{percentile=\"{:02}\"}} {}", label, label, percentile, value));
+                    data.push(format!(
+                        "# TYPE {} gauge\n{}{{percentile=\"{:02}\"}} {}",
+                        label, label, percentile, value
+                    ));
                 }
             }
         }

--- a/src/exposition/mod.rs
+++ b/src/exposition/mod.rs
@@ -45,14 +45,10 @@ impl MetricsSnapshot {
             let output = metric.output();
             match output {
                 Output::Reading => {
-                    if let Some(ref count_label) = self.count_label {
-                        data.push(format!("{}/{} {}", label, count_label, value));
-                    } else {
-                        data.push(format!("{} {}", label, value));
-                    }
+                    data.push(format!("# TYPE {} gauge\n{} {}", label, label, value));
                 }
                 Output::Percentile(percentile) => {
-                    data.push(format!("{}/histogram/p{:02} {}", label, percentile, value));
+                    data.push(format!("# TYPE {} gauge\n{}{{percentile=\"{:02}\"}} {}", label, label, percentile, value));
                 }
             }
         }


### PR DESCRIPTION
Similar to https://github.com/twitter/rpc-perf/pull/317 the metrics
exposition format is not strictly correct after changing the
percentile representation to use decimal format.

This change adds prometheus type annoations and changes the format
for percentiles to encode the percentile as a label value.
