### PR TITLE
interrupts: allow new-style network interface names

### DIFF
--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -226,7 +226,7 @@ impl Interrupt {
                             InterruptStatistic::Nvme
                         }
                         Some(label) => {
-                            if label.starts_with("mlx") || label.starts_with("eth") {
+                            if label.starts_with("mlx") || label.starts_with("eth") || label.starts_with("enp") {
                                 if let Some(previous) =
                                     result.get_mut(&InterruptStatistic::Node0Network)
                                 {

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -226,7 +226,10 @@ impl Interrupt {
                             InterruptStatistic::Nvme
                         }
                         Some(label) => {
-                            if label.starts_with("mlx") || label.starts_with("eth") || label.starts_with("enp") {
+                            if label.starts_with("mlx")
+                                || label.starts_with("eth")
+                                || label.starts_with("enp")
+                            {
                                 if let Some(previous) =
                                     result.get_mut(&InterruptStatistic::Node0Network)
                                 {


### PR DESCRIPTION
Interrupts sampler previously only counted network interrupts if
the adapter had an old-style 'eth*' name.

Adds 'enp*' match to the interrupt sampler to allow counting those
interrupts towards the network interrupts counts.
