### PR TITLE
Adding srtt metric in the TCP sampler via BPF

### DIFF
--- a/configs/tcptest.toml
+++ b/configs/tcptest.toml
@@ -1,4 +1,4 @@
-# This example configuration covers detailed configuration for each sampler
+# This configuration is used for testing the tcp sampler
 
 [general]
 listen = "0.0.0.0:4242"
@@ -16,18 +16,6 @@ enabled = true
 # Enable BPF sampling
 bpf = true
 
-# Sampling interval, in milliseconds, for this sampler
-# interval = 1000
-
 statistics = [
 	"tcp/srtt",
 ]
-
-# The set of exported percentiles can be controlled by specifying them here
-# percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
-# ]

--- a/configs/tcptest.toml
+++ b/configs/tcptest.toml
@@ -1,0 +1,33 @@
+# This example configuration covers detailed configuration for each sampler
+
+[general]
+listen = "0.0.0.0:4242"
+logging = "debug"
+interval = 1000
+window = 5
+
+# Per-sampler configuration sections
+[samplers]
+# The tcp sampler provides telemetry about tcp traffic
+[samplers.tcp]
+# Controls whether to use this sampler
+enabled = true
+
+# Enable BPF sampling
+bpf = true
+
+# Sampling interval, in milliseconds, for this sampler
+# interval = 1000
+
+statistics = [
+	"tcp/srtt",
+]
+
+# The set of exported percentiles can be controlled by specifying them here
+# percentiles = [
+# 	"1.0",
+# 	"10.0",
+# 	"50.0",
+# 	"90.0",
+# 	"99.0",
+# ]

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -93,7 +93,11 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
 int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
     struct tcp_sock *ts = tcp_sk(sk);
-    u64 index = value_to_index2(ts->srtt_us >> 3); // it's gonna be in microsecond
+    // we do >> 3 because the value recorded in ts->srtt_us is actually 8 times
+    // the value of real srtt for easier calculation.
+    // see the thread in: https://lkml.org/lkml/1998/9/12/41
+    // and source code in: https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp_input.c#L797
+    u64 index = value_to_index2(ts->srtt_us >> 3);
     srtt.increment(index);
     return 0;
 }

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -148,6 +148,10 @@ impl Tcp {
                     .handler("trace_tcp_rcv_state_process")
                     .function("tcp_rcv_state_process")
                     .attach(&mut bpf)?;
+                bcc::Kprobe::new()
+                    .handler("trace_tcp_rcv")
+                    .function("tcp_rcv_established")
+                    .attach(&mut bpf)?;
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))
             }
@@ -164,7 +168,7 @@ impl Tcp {
         if let Some(file) = &mut self.proc_net_snmp {
             let parsed = crate::common::nested_map_from_file(file).await?;
             let time = Instant::now();
-            for statistic in &self.statistics {
+            for statistic in &self.statistics {                
                 if let Some((pkey, lkey)) = statistic.keys() {
                     if let Some(inner) = parsed.get(pkey) {
                         if let Some(value) = inner.get(lkey) {

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -71,6 +71,8 @@ pub enum TcpStatistic {
     AbortOnMemory,
     #[strum(serialize = "tcp/abort/on_timeout")]
     AbortOnTimeout,
+    #[strum(serialize = "tcp/srtt")]
+    SmoothedRoundTripTime,
 }
 
 impl TcpStatistic {
@@ -105,6 +107,7 @@ impl TcpStatistic {
     pub fn bpf_table(self) -> Option<&'static str> {
         match self {
             Self::ConnectLatency => Some("connlat"),
+            Self::SmoothedRoundTripTime => Some("srtt"),
             _ => None,
         }
     }


### PR DESCRIPTION
Problem

Currently the TCP sampler does not support TCP RTT (round-trip time) metric, which is useful to analyse the quality of the network.

Solution

Introduced a new kprobe using BPF and collect RTT metric in a histogram in kernel space, and export it to the TCP sampler.

Result

The metric is supported as 'tcp/srtt' metric
