### PR TITLE
Convert metrics to use `rustcommon-metrics-v2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "async-trait",
  "bcc",
  "clap",
+ "crossbeam",
  "ctrlc",
  "dashmap 4.0.2",
  "json",
@@ -1338,9 +1339,11 @@ dependencies = [
  "regex",
  "reqwest",
  "rustcommon-atomics",
+ "rustcommon-heatmap",
  "rustcommon-logger",
  "rustcommon-metrics",
  "rustcommon-metrics-v2",
+ "rustcommon-streamstats",
  "serde",
  "serde_derive",
  "strum",
@@ -1372,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "serde",
 ]
@@ -1380,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -1391,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1400,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "log 0.4.14",
  "time",
@@ -1409,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "crossbeam",
  "dashmap 3.11.10",
@@ -1422,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1433,18 +1436,20 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "linkme",
  "once_cell",
  "parking_lot",
+ "rustcommon-atomics",
+ "rustcommon-heatmap",
  "rustcommon-metrics-derive",
 ]
 
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -482,42 +482,42 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-core",
@@ -716,9 +716,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -780,10 +780,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.4"
+name = "linkme"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "04f7a548defb4c688d16c333586fe92907d774c2df78037ab098b8f7202bf7fb"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcc41894750103e29b7d4b0763bbf807eb723ce78626c461cf6dadb84124ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -931,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1037,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -1095,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -1106,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1149,6 +1169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,9 +1186,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1310,6 +1340,7 @@ dependencies = [
  "rustcommon-atomics",
  "rustcommon-logger",
  "rustcommon-metrics",
+ "rustcommon-metrics-v2",
  "serde",
  "serde_derive",
  "strum",
@@ -1341,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "serde",
 ]
@@ -1349,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -1360,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1369,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "log 0.4.14",
  "time",
@@ -1378,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "crossbeam",
  "dashmap 3.11.10",
@@ -1389,9 +1420,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcommon-metrics-derive"
+version = "0.1.0"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rustcommon-metrics-v2"
+version = "0.1.0"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
+dependencies = [
+ "linkme",
+ "once_cell",
+ "parking_lot",
+ "rustcommon-metrics-derive",
+]
+
+[[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#0f249acb08369db03854a38ddf13c5a2622cedee"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1443,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1459,15 +1512,15 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -1576,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1622,18 +1675,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1690,9 +1743,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1731,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1898,9 +1951,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1910,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1925,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
+checksum = "a87d738d4abc4cf22f6eb142f5b9a81301331ee3c767f2fef2fda4e325492060"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1937,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1947,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1960,15 +2013,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "serde",
 ]
@@ -1383,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "crossbeam",
  "rustcommon-atomics",
@@ -1394,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "log 0.4.14",
  "time",
@@ -1412,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "crossbeam",
  "dashmap 3.11.10",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1436,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "linkme",
  "once_cell",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#5b60456f099f3e7fbecd81cade8ce08eb4da1349"
+source = "git+https://github.com/twitter/rustcommon?branch=master#ce8c10abcf2a1e9a69a40d235f02ed16ca6eaf36"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { version = "0.11.4", features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-metrics-v2 = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 serde = "1.0.126"
 serde_derive = "1.0.126"
 strum = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1.50"
 bcc = { version = "0.0.31", optional = true }
 clap = "2.33.3"
 ctrlc = { version = "3.1.9", features = ["termination"] }
+crossbeam = "0.8.1"
 dashmap = "4.0.2"
 json = "0.12.4"
 kafka = { version = "0.8.0", optional = true }
@@ -28,7 +29,9 @@ reqwest = { version = "0.11.4", features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
-rustcommon-metrics-v2 = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-metrics-v2 = { git = "https://github.com/twitter/rustcommon", branch = "master", features = [ "heatmap" ] }
+rustcommon-streamstats = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-heatmap = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 serde = "1.0.126"
 serde_derive = "1.0.126"
 strum = "0.21.0"

--- a/src/exposition/kafka.rs
+++ b/src/exposition/kafka.rs
@@ -20,7 +20,7 @@ pub struct KafkaProducer {
 }
 
 impl KafkaProducer {
-    pub fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU64, AtomicU32>>) -> Self {
         Self {
             snapshot: MetricsSnapshot::new(metrics, config.general().reading_suffix()),
             producer: Producer::from_hosts(config.exposition().kafka().hosts())

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,9 @@ use rustcommon_logger::Logger;
 use rustcommon_metrics::*;
 use tokio::runtime::Builder;
 
+#[macro_use]
+mod metrics;
+
 mod common;
 mod config;
 mod exposition;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ extern crate rustcommon_logger;
 #[macro_use]
 extern crate anyhow;
 
+extern crate rustcommon_metrics as rustcommon_metrics_legacy;
+
 use rustcommon_atomics::{Atomic, Ordering};
 use std::sync::Arc;
 

--- a/src/metrics/heatmap.rs
+++ b/src/metrics/heatmap.rs
@@ -1,0 +1,190 @@
+#![allow(dead_code)]
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::ops::Deref;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use crossbeam::atomic::AtomicCell;
+use rustcommon_atomics::{Atomic, AtomicU32, AtomicU64};
+use rustcommon_heatmap::AtomicHeatmap;
+use rustcommon_metrics_v2::{Counter, DynBoxedMetric, Gauge, Metric};
+
+type Heatmap = AtomicHeatmap<u64, AtomicU32>;
+
+pub struct SampledHeatmap {
+    refreshed: AtomicCell<Option<Instant>>,
+    reading: AtomicU64,
+    heatmap: Heatmap,
+    percentiles: Cow<'static, [f64]>,
+}
+
+impl SampledHeatmap {
+    pub fn new(
+        heatmap: Heatmap,
+        percentiles: impl Into<Cow<'static, [f64]>>,
+    ) -> Self {
+        Self {
+            refreshed: AtomicCell::new(None),
+            reading: AtomicU64::new(0),
+            heatmap,
+            percentiles: percentiles.into(),
+        }
+    }
+
+    pub fn percentiles(&self) -> &[f64] {
+        &self.percentiles
+    }
+
+    pub fn heatmap(&self) -> &Heatmap {
+        &self.heatmap
+    }
+
+    pub fn record_counter(&self, time: Instant, value: u64) {
+        let t0 = match self.refreshed.load() {
+            Some(t0) if time <= t0 => return,
+            Some(t0) => t0,
+            None => {
+                self.refreshed.store(Some(time));
+                self.reading.store(value, Ordering::Release);
+                return;
+            }
+        };
+
+        self.refreshed.store(Some(time));
+        let v0 = self.reading.swap(value, Ordering::Release);
+        let dt = time - t0;
+        let dv = (value - v0) as f64;
+        let rate = (dv / dt.as_secs_f64()).ceil();
+        self.heatmap.increment(time, rate as _, 1);
+    }
+
+    pub fn record_gauge(&self, time: Instant, value: i64) {
+        let t0 = match self.refreshed.load() {
+            Some(t0) if time <= t0 => return,
+            Some(t0) => t0,
+            None => {
+                self.refreshed.store(Some(time));
+                self.reading.store(value as _, Ordering::Release);
+                return;
+            }
+        };
+
+        self.refreshed.store(Some(time));
+        let v0 = self.reading.swap(value as _, Ordering::Release) as i64;
+        let dt = time - t0;
+        let dv = (value - v0) as f64;
+        let rate = (dv / dt.as_secs_f64()).ceil();
+        self.heatmap.increment(time, rate as _, 1);
+    }
+}
+
+impl Deref for SampledHeatmap {
+    type Target = Heatmap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.heatmap
+    }
+}
+
+impl Metric for SampledHeatmap {
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+}
+
+/// A combination of two metrics: a counter and a heatmap of its rate of change
+pub struct HeatmapSummarizedCounter {
+    counter: DynBoxedMetric<Counter>,
+    heatmap: DynBoxedMetric<SampledHeatmap>,
+}
+
+impl HeatmapSummarizedCounter {
+    pub fn new(name: &str, span: Duration, percentiles: &[f64]) -> Self {
+        Self {
+            counter: DynBoxedMetric::new(Counter::new(), name.to_owned()),
+            heatmap: DynBoxedMetric::new(
+                SampledHeatmap::new(
+                    AtomicHeatmap::new(1_000_000_000, 2, span, Duration::from_secs(1)),
+                    percentiles.to_owned(),
+                ),
+                format!("{}/histogram", name),
+            ),
+        }
+    }
+
+    pub fn disable(&mut self) {
+        rustcommon_metrics_v2::dynmetrics::unregister(&*self.counter);
+        rustcommon_metrics_v2::dynmetrics::unregister(&*self.heatmap);
+    }
+
+    pub fn counter(&self) -> &Counter {
+        &self.counter
+    }
+
+    pub fn heatmap(&self) -> &SampledHeatmap {
+        &self.heatmap
+    }
+
+    pub fn increment(&self, time: Instant) {
+        self.add(time, 1)
+    }
+
+    pub fn add(&self, time: Instant, value: u64) {
+        let value = self.counter.add(value) + value;
+        self.heatmap.record_counter(time, value as _)
+    }
+
+    pub fn store(&self, time: Instant, value: u64) {
+        self.counter.set(value);
+        self.heatmap.record_counter(time, value);
+    }
+}
+
+pub struct HeatmapSummarizedGauge {
+    gauge: DynBoxedMetric<Gauge>,
+    heatmap: DynBoxedMetric<SampledHeatmap>,
+}
+
+impl HeatmapSummarizedGauge {
+    pub fn new(name: &str, span: Duration, percentiles: &[f64]) -> Self {
+        Self {
+            gauge: DynBoxedMetric::new(Gauge::new(), name.to_owned()),
+            heatmap: DynBoxedMetric::new(
+                SampledHeatmap::new(
+                    AtomicHeatmap::new(1_000_000_000, 2, span, Duration::from_secs(1)),
+                    percentiles.to_owned(),
+                ),
+                format!("{}/histogram", name),
+            ),
+        }
+    }
+
+    pub fn disable(&mut self) {
+        rustcommon_metrics_v2::dynmetrics::unregister(&*self.gauge);
+        rustcommon_metrics_v2::dynmetrics::unregister(&*self.heatmap);
+    }
+
+    pub fn gauge(&self) -> &Gauge {
+        &self.gauge
+    }
+
+    pub fn heatmap(&self) -> &SampledHeatmap {
+        &self.heatmap
+    }
+
+    pub fn increment(&self, time: Instant) {
+        self.add(time, 1)
+    }
+
+    pub fn add(&self, time: Instant, value: i64) {
+        let value = self.gauge.add(value) + value;
+        self.heatmap.record_gauge(time, value)
+    }
+
+    pub fn store(&self, time: Instant, value: i64) {
+        self.gauge.set(value);
+        self.heatmap.record_gauge(time, value);
+    }
+}

--- a/src/metrics/heatmap.rs
+++ b/src/metrics/heatmap.rs
@@ -14,6 +14,7 @@ use rustcommon_heatmap::AtomicHeatmap;
 use rustcommon_metrics_v2::{DynBoxedMetric, Metric};
 
 use super::LazyMetric;
+use crate::samplers::CommonSamplerConfig;
 
 type Heatmap = AtomicHeatmap<u64, AtomicU32>;
 
@@ -63,6 +64,10 @@ pub struct SummarizedDistribution {
 }
 
 impl SummarizedDistribution {
+    pub fn with_config(config: &CommonSamplerConfig) -> Self {
+        Self::new(config.span, &config.percentiles)
+    }
+
     pub fn new(span: Duration, percentiles: &[f64]) -> Self {
         Self {
             heatmap: DynBoxedMetric::unregistered(LazyMetric::new(SampledHeatmap::new(

--- a/src/metrics/heatmap.rs
+++ b/src/metrics/heatmap.rs
@@ -1,3 +1,7 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 #![allow(dead_code)]
 
 use std::any::Any;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,28 @@
+mod heatmap;
+
+pub use self::heatmap::{HeatmapSummarizedCounter, HeatmapSummarizedGauge, SampledHeatmap};
+pub use rustcommon_metrics_v2::{metric, Counter, DynBoxedMetric, Gauge, Heatmap};
+
+/// A short form for a sequence of if statements.
+/// 
+/// # Example
+/// ```
+/// # let i = 0;
+/// if_block! {
+///     if i % 2 == 0 => println!("divisible by 2");
+///     if i % 3 == 0 => println!("divisible by 3");
+///     if i % 4 == 0 => println!("divisible by 4");
+///     // etc..
+/// }
+/// ```
+macro_rules! if_block {
+    { if let $pat:pat = $val:expr => $then:expr ; $( $rest:tt )* } => {{
+    if let $pat = $val { $then; }
+    if_block! { $( $rest )* }
+    }};
+    { if $cond:expr => $then:expr ; $( $rest:tt )* } => {{
+        if $cond { $then; }
+        if_block! { $( $rest )* }
+    }};
+    {} => {};
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,10 +1,15 @@
+use std::any::Any;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicBool, Ordering};
+
 mod heatmap;
 
 pub use self::heatmap::{HeatmapSummarizedCounter, HeatmapSummarizedGauge, SampledHeatmap};
+use rustcommon_metrics_v2::Metric;
 pub use rustcommon_metrics_v2::{metric, Counter, DynBoxedMetric, Gauge, Heatmap};
 
 /// A short form for a sequence of if statements.
-/// 
+///
 /// # Example
 /// ```
 /// # let i = 0;
@@ -25,4 +30,68 @@ macro_rules! if_block {
         if_block! { $( $rest )* }
     }};
     {} => {};
+}
+
+/// A metric that isn't enabled until it is first accessed.
+///
+/// When used as a static metric it won't allow retrieving a `&dyn Any` until
+/// it has been accessed at least once.
+pub struct LazyMetric<M> {
+    metric: M,
+    active: AtomicBool,
+}
+
+impl<M> LazyMetric<M> {
+    pub const fn new(metric: M) -> Self {
+        Self {
+            metric,
+            active: AtomicBool::new(false),
+        }
+    }
+
+    pub fn force(this: &Self) -> &M {
+        this.active.store(true, Ordering::Relaxed);
+        &this.metric
+    }
+
+    pub fn get(this: &Self) -> Option<&M> {
+        match this.active.load(Ordering::Relaxed) {
+            true => Some(&this.metric),
+            false => None,
+        }
+    }
+}
+
+impl<M: Metric> Metric for LazyMetric<M> {
+    fn is_enabled(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    fn as_any(&self) -> Option<&dyn Any> {
+        Self::get(self).map(|x| x as &dyn Any)
+    }
+}
+
+impl<M> Deref for LazyMetric<M> {
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        Self::force(self)
+    }
+}
+
+impl<M> DerefMut for LazyMetric<M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        *self.active.get_mut() = true;
+        &mut self.metric
+    }
+}
+
+impl<M: Default> Default for LazyMetric<M> {
+    fn default() -> Self {
+        Self {
+            metric: M::default(),
+            active: AtomicBool::new(false),
+        }
+    }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,3 +1,7 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
 use std::any::Any;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/metrics/stream.rs
+++ b/src/metrics/stream.rs
@@ -1,0 +1,179 @@
+// Copyright 2019-2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#![allow(dead_code)]
+
+use std::any::Any;
+use std::borrow::Cow;
+use std::ops::Deref;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use crossbeam::atomic::AtomicCell;
+use rustcommon_atomics::{Atomic, AtomicU32, AtomicU64};
+use rustcommon_heatmap::AtomicHeatmap;
+use rustcommon_metrics_v2::{Counter, DynBoxedMetric, Gauge, Metric};
+
+use super::LazyMetric;
+use rustcommon_streamstats::AtomicStreamstats;
+
+type Heatmap = AtomicHeatmap<u64, AtomicU32>;
+
+pub struct SampledStream {
+    refreshed: AtomicCell<Option<Instant>>,
+    reading: AtomicU64,
+    stream: AtomicStreamstats<AtomicU64>,
+    percentiles: Cow<'static, [f64]>,
+}
+
+impl SampledStream {
+    pub fn new(
+        stream: AtomicStreamstats<AtomicU64>,
+        percentiles: impl Into<Cow<'static, [f64]>>,
+    ) -> Self {
+        Self {
+            refreshed: AtomicCell::new(None),
+            reading: AtomicU64::new(0),
+            stream,
+            percentiles: percentiles.into(),
+        }
+    }
+
+    pub fn percentiles(&self) -> &[f64] {
+        &self.percentiles
+    }
+
+    pub fn record_counter(&self, time: Instant, value: u64) {
+        let t0 = match self.refreshed.load() {
+            Some(t0) if time <= t0 => return,
+            Some(t0) => t0,
+            None => {
+                self.refreshed.store(Some(time));
+                self.reading.store(value, Ordering::Release);
+                return;
+            }
+        };
+
+        self.refreshed.store(Some(time));
+        let v0 = self.reading.swap(value, Ordering::Release);
+        let dt = time - t0;
+        let dv = (value - v0) as f64;
+        let rate = (dv / dt.as_secs_f64()).ceil();
+        self.stream.insert(rate as _);
+    }
+
+    pub fn record_gauge(&self, time: Instant, value: i64) {
+        let t0 = match self.refreshed.load() {
+            Some(t0) if time <= t0 => return,
+            Some(t0) => t0,
+            None => {
+                self.refreshed.store(Some(time));
+                self.reading.store(value as _, Ordering::Release);
+                return;
+            }
+        };
+
+        self.refreshed.store(Some(time));
+        let v0 = self.reading.swap(value as _, Ordering::Release) as i64;
+        let dt = time - t0;
+        let dv = (value - v0) as f64;
+        let rate = (dv / dt.as_secs_f64()).ceil();
+        self.stream.insert(rate as _);
+    }
+}
+
+impl Deref for SampledStream {
+    type Target = AtomicStreamstats<AtomicU64>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl Metric for SampledStream {
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
+}
+
+/// A combination of two metrics: a counter and a heatmap of its rate of change
+pub struct StreamSummarizedCounter {
+    counter: DynBoxedMetric<LazyMetric<Counter>>,
+    stream: DynBoxedMetric<LazyMetric<SampledStream>>,
+}
+
+impl StreamSummarizedCounter {
+    pub fn new(capacity: usize, percentiles: &[f64]) -> Self {
+        Self {
+            counter: DynBoxedMetric::unregistered(LazyMetric::new(Counter::new())),
+            stream: DynBoxedMetric::unregistered(LazyMetric::new(SampledStream::new(
+                AtomicStreamstats::new(capacity),
+                percentiles.to_owned(),
+            ))),
+        }
+    }
+
+    pub fn register(&mut self, name: &str) {
+        self.counter.register(name.to_owned());
+        self.stream.register(name.to_owned());
+    }
+
+    pub fn counter(&self) -> &Counter {
+        &self.counter
+    }
+
+    pub fn increment(&self, time: Instant) {
+        self.add(time, 1)
+    }
+
+    pub fn add(&self, time: Instant, value: u64) {
+        let value = self.counter.add(value) + value;
+        self.stream.record_counter(time, value as _)
+    }
+
+    pub fn store(&self, time: Instant, value: u64) {
+        self.counter.set(value);
+        self.stream.record_counter(time, value);
+    }
+}
+
+pub struct StreamSummarizedGauge {
+    gauge: DynBoxedMetric<LazyMetric<Gauge>>,
+    stream: DynBoxedMetric<LazyMetric<SampledStream>>,
+}
+
+impl StreamSummarizedGauge {
+    pub fn new(capacity: usize, percentiles: &[f64]) -> Self {
+        Self {
+            gauge: DynBoxedMetric::unregistered(LazyMetric::new(Gauge::new())),
+            stream: DynBoxedMetric::unregistered(LazyMetric::new(SampledStream::new(
+                AtomicStreamstats::new(capacity),
+                percentiles.to_owned(),
+            ))),
+        }
+    }
+
+    pub fn register(&mut self, name: &str) {
+        self.gauge.register(name.to_owned());
+        self.stream.register(name.to_owned());
+    }
+
+    pub fn gauge(&self) -> &Gauge {
+        &self.gauge
+    }
+
+    pub fn increment(&self, time: Instant) {
+        self.add(time, 1)
+    }
+
+    pub fn add(&self, time: Instant, value: i64) {
+        let value = self.gauge.add(value) + value;
+        self.stream.record_gauge(time, value)
+    }
+
+    pub fn store(&self, time: Instant, value: i64) {
+        self.gauge.set(value);
+        self.stream.record_gauge(time, value);
+    }
+}

--- a/src/metrics/stream.rs
+++ b/src/metrics/stream.rs
@@ -17,6 +17,7 @@ use rustcommon_metrics_v2::{Counter, DynBoxedMetric, Gauge, Metric};
 
 use super::LazyMetric;
 use rustcommon_streamstats::AtomicStreamstats;
+use crate::samplers::CommonSamplerConfig;
 
 type Heatmap = AtomicHeatmap<u64, AtomicU32>;
 
@@ -104,6 +105,10 @@ pub struct StreamSummarizedCounter {
 }
 
 impl StreamSummarizedCounter {
+    pub fn with_config(config: &CommonSamplerConfig) -> Self {
+        Self::new(config.capacity, &config.percentiles)
+    }
+
     pub fn new(capacity: usize, percentiles: &[f64]) -> Self {
         Self {
             counter: DynBoxedMetric::unregistered(LazyMetric::new(Counter::new())),
@@ -144,6 +149,10 @@ pub struct StreamSummarizedGauge {
 }
 
 impl StreamSummarizedGauge {
+    pub fn with_config(config: &CommonSamplerConfig) -> Self {
+        Self::new(config.capacity, &config.percentiles)
+    }
+    
     pub fn new(capacity: usize, percentiles: &[f64]) -> Self {
         Self {
             gauge: DynBoxedMetric::unregistered(LazyMetric::new(Gauge::new())),

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -25,6 +25,7 @@ use crate::Sampler;
 
 mod config;
 mod stat;
+mod next;
 
 pub use config::*;
 pub use stat::*;

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -28,7 +28,6 @@ mod stat;
 
 pub use config::*;
 pub use stat::*;
-use std::iter::FromIterator;
 
 #[allow(dead_code)]
 pub struct Cpu {
@@ -72,6 +71,7 @@ impl Sampler for Cpu {
 
         if sampler.sampler_config().enabled() {
             sampler.register();
+            sampler.stats.register(&sampler.statistics.iter().copied().collect());
         }
 
         // we initialize perf last so we can delay
@@ -85,10 +85,6 @@ impl Sampler for Cpu {
                 }
             }
         }
-
-        sampler
-            .stats
-            .disable_unwanted(&HashSet::from_iter(sampler.statistics.iter().copied()));
 
         // delay by half the sample interval so that we land between perf
         // counter updates
@@ -259,6 +255,7 @@ impl Cpu {
             }
 
             let time = Instant::now();
+            info!("freq: {:?}", result);
             for frequency in result {
                 self.stats.frequency.store(time, frequency);
             }

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -295,9 +295,7 @@ impl Cpu {
     }
 
     async fn sample_cstates(&mut self) -> Result<(), std::io::Error> {
-        use self::CpuStatistic::*;
-
-        let mut result = HashMap::<CpuStatistic, u64>::new();
+        let mut result = HashMap::<CState, u64>::new();
 
         // populate the cpu cache if empty
         if self.cpus.is_empty() {
@@ -362,18 +360,11 @@ impl Cpu {
                         let mut reader = BufReader::new(file);
                         if let Ok(time) = reader.read_u64().await {
                             if let Some(state) = state.split('-').next() {
-                                let metric = match CState::from_str(&state) {
-                                    Ok(CState::C0) => CpuStatistic::CstateC0Time,
-                                    Ok(CState::C1) => CpuStatistic::CstateC1Time,
-                                    Ok(CState::C1E) => CpuStatistic::CstateC1ETime,
-                                    Ok(CState::C2) => CpuStatistic::CstateC2Time,
-                                    Ok(CState::C3) => CpuStatistic::CstateC3Time,
-                                    Ok(CState::C6) => CpuStatistic::CstateC6Time,
-                                    Ok(CState::C7) => CpuStatistic::CstateC7Time,
-                                    Ok(CState::C8) => CpuStatistic::CstateC8Time,
-                                    _ => continue,
+                                let cstate = match CState::from_str(&state) {
+                                    Ok(cstate) => cstate,
+                                    _ => continue
                                 };
-                                let counter = result.entry(metric).or_insert(0);
+                                let counter = result.entry(cstate).or_insert(0);
                                 *counter += time * MICROSECOND;
                             }
                         }
@@ -384,14 +375,14 @@ impl Cpu {
 
         let time = Instant::now();
         if_block! {
-            if let Some(&value) = result.get(&CstateC0Time) => self.stats.cstate_c0_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC1Time) => self.stats.cstate_c1_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC1ETime) => self.stats.cstate_c1e_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC2Time) => self.stats.cstate_c2_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC3Time) => self.stats.cstate_c3_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC6Time) => self.stats.cstate_c6_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC7Time) => self.stats.cstate_c7_time.store(time, value);
-            if let Some(&value) = result.get(&CstateC8Time) => self.stats.cstate_c8_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C0) => self.stats.cstate_c0_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C1) => self.stats.cstate_c1_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C1E) => self.stats.cstate_c1e_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C2) => self.stats.cstate_c2_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C3) => self.stats.cstate_c3_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C6) => self.stats.cstate_c6_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C7) => self.stats.cstate_c7_time.store(time, value);
+            if let Some(&value) = result.get(&CState::C8) => self.stats.cstate_c8_time.store(time, value);
         }
 
         Ok(())

--- a/src/samplers/cpu/next.rs
+++ b/src/samplers/cpu/next.rs
@@ -1,0 +1,630 @@
+#![allow(dead_code)]
+
+use super::config::*;
+use crate::common::bpf::BPF;
+use crate::common::*;
+use crate::config::SamplerConfig;
+use crate::metrics::*;
+use crate::samplers::Common;
+use crate::Sampler;
+
+use super::CpuStatistic;
+use crate::samplers::cpu::CState;
+use async_trait::async_trait;
+#[cfg(feature = "bpf")]
+use bcc::perf_event::{Event, SoftwareEvent};
+#[cfg(feature = "bpf")]
+use bcc::{PerfEvent, PerfEventArray};
+use regex::Regex;
+use serde_derive::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::io::SeekFrom;
+use std::iter::Cycle;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use strum_macros::{AsStaticStr, EnumIter, EnumString, IntoStaticStr};
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader};
+use std::str::FromStr;
+
+macro_rules! stats_struct {
+    {
+        $( #[$attr:meta] )*
+        $svis:vis struct $struct:ident : $stats:ident {
+            $( $vis:vis $field:ident: $ty:ty = $name:literal ),* $(,)?
+        }
+    } => {
+        $( #[$attr] )*
+        $svis struct $struct{
+            $( $vis $field: $ty, )*
+        }
+
+        impl $struct {
+            #[allow(dead_code)]
+            pub fn register(&mut self, enabled: &::std::collections::HashSet<$stats>) {
+                $(
+                    if enabled.contains(&$stats::$field) {
+                        self.$field.register($name)
+                    }
+                )*
+            }
+
+            #[allow(dead_code)]
+            pub fn with_config(config: &$crate::samplers::CommonSamplerConfig) -> Self {
+                Self {
+                    $( $field: <$ty>::with_config(config), )*
+                }
+            }
+        }
+
+        #[derive(
+            Copy, Clone, Debug, Eq, PartialEq, Hash,
+            Serialize, Deserialize, EnumIter, EnumString, IntoStaticStr,
+            AsStaticStr,
+        )]
+        #[serde(deny_unknown_fields, try_from = "&str", into = "&str")]
+        #[allow(non_camel_case_types)]
+        $svis enum $stats {
+            $(
+                #[strum(serialize = $name)]
+                $field,
+            )*
+        }
+
+        impl ::std::convert::TryFrom<&str> for $stats {
+            type Error = ::strum::ParseError;
+
+            fn try_from(s: &str) -> Result<Self, Self::Error> {
+                use ::std::str::FromStr;
+
+                Self::from_str(s)
+            }
+        }
+
+        impl ::rustcommon_metrics::Statistic<
+            ::rustcommon_atomics::AtomicU64,
+            ::rustcommon_atomics::AtomicU32> for $stats {
+            fn name(&self) -> &str {
+                (*self).into()
+            }
+
+            // Not used but required
+            fn source(&self) -> ::rustcommon_metrics::Source {
+                unimplemented!()
+            }
+        }
+    }
+}
+
+stats_struct! {
+    pub(super) struct CpuStats : CpuStatKind {
+        pub usage_user: StreamSummarizedCounter        = "cpu/usage/user",
+        pub usage_nice: StreamSummarizedCounter        = "cpu/usage/nice",
+        pub usage_system: StreamSummarizedCounter      = "cpu/usage/system",
+        pub usage_idle: StreamSummarizedCounter        = "cpu/usage/idle",
+        pub usage_irq: StreamSummarizedCounter         = "cpu/usage/irq",
+        pub usage_softirq: StreamSummarizedCounter     = "cpu/usage/softirq",
+        pub usage_steal: StreamSummarizedCounter       = "cpu/usage/steal",
+        pub usage_guest: StreamSummarizedCounter       = "cpu/usage/guest",
+        pub usage_guest_nice: StreamSummarizedCounter  = "cpu/usage/guestnice",
+        pub cache_miss: StreamSummarizedCounter        = "cpu/cache/miss",
+        pub cache_access: StreamSummarizedCounter      = "cpu/cache/access",
+        pub bpu_branches: StreamSummarizedCounter      = "cpu/bpu/branch",
+        pub bpu_miss: StreamSummarizedCounter          = "cpu/bpu/miss",
+        pub cycles: StreamSummarizedCounter            = "cpu/cycles",
+        pub dtlb_load_miss: StreamSummarizedCounter    = "cpu/dtlb/load/miss",
+        pub dtlb_load_access: StreamSummarizedCounter  = "cpu/dtlb/load/access",
+        pub dtlb_store_access: StreamSummarizedCounter = "cpu/dtlb/store/access",
+        pub dtlb_store_miss: StreamSummarizedCounter   = "cpu/dtlb/store/miss",
+        pub instructions: StreamSummarizedCounter      = "cpu/instructions",
+        pub reference_cycles: StreamSummarizedCounter  = "cpu/reference_cycles",
+        pub cstate_c0_time: StreamSummarizedCounter    = "cpu/cstate/c0/time",
+        pub cstate_c1_time: StreamSummarizedCounter    = "cpu/cstate/c1/time",
+        pub cstate_c1e_time: StreamSummarizedCounter   = "cpu/cstate/c1e/time",
+        pub cstate_c2_time: StreamSummarizedCounter    = "cpu/cstate/c2/time",
+        pub cstate_c3_time: StreamSummarizedCounter    = "cpu/cstate/c3/time",
+        pub cstate_c6_time: StreamSummarizedCounter    = "cpu/cstate/c6/time",
+        pub cstate_c7_time: StreamSummarizedCounter    = "cpu/cstate/c7/time",
+        pub cstate_c8_time: StreamSummarizedCounter    = "cpu/cstate/c8/time",
+        pub frequency: StreamSummarizedGauge           = "cpu/frequency",
+    }
+}
+
+pub struct CpuSampler {
+    common: Common,
+    stats: CpuStats,
+
+    cpus: HashSet<String>,
+    cstates: HashMap<String, String>,
+    cstate_files: HashMap<String, HashMap<String, File>>,
+    perf: Option<Arc<Mutex<BPF>>>,
+    tick_duration: u64,
+    proc_cpuinfo: Option<File>,
+    proc_stat: Option<File>,
+}
+
+// Note: not needed as part of the design, just for interoperability at the moment
+impl From<CpuStatistic> for CpuStatKind {
+    fn from(stat: CpuStatistic) -> Self {
+        use self::CpuStatistic::*;
+
+        match stat {
+            UsageUser => CpuStatKind::usage_user,
+            UsageNice => CpuStatKind::usage_nice,
+            UsageSystem => CpuStatKind::usage_system,
+            UsageIdle => CpuStatKind::usage_idle,
+            UsageIrq => CpuStatKind::usage_irq,
+            UsageSoftirq => CpuStatKind::usage_softirq,
+            UsageSteal => CpuStatKind::usage_steal,
+            UsageGuest => CpuStatKind::usage_guest,
+            UsageGuestNice => CpuStatKind::usage_guest_nice,
+            CacheMiss => CpuStatKind::cache_miss,
+            CacheAccess => CpuStatKind::cache_access,
+            BpuBranches => CpuStatKind::bpu_branches,
+            BpuMiss => CpuStatKind::bpu_miss,
+            Cycles => CpuStatKind::cycles,
+            DtlbLoadMiss => CpuStatKind::dtlb_load_miss,
+            DtlbLoadAccess => CpuStatKind::dtlb_load_access,
+            DtlbStoreAccess => CpuStatKind::dtlb_store_access,
+            DtlbStoreMiss => CpuStatKind::dtlb_store_miss,
+            Instructions => CpuStatKind::instructions,
+            ReferenceCycles => CpuStatKind::reference_cycles,
+            CstateC0Time => CpuStatKind::cstate_c0_time,
+            CstateC1Time => CpuStatKind::cstate_c1_time,
+            CstateC1ETime => CpuStatKind::cstate_c1e_time,
+            CstateC2Time => CpuStatKind::cstate_c2_time,
+            CstateC3Time => CpuStatKind::cstate_c3_time,
+            CstateC6Time => CpuStatKind::cstate_c6_time,
+            CstateC7Time => CpuStatKind::cstate_c7_time,
+            CstateC8Time => CpuStatKind::cstate_c8_time,
+            Frequency => CpuStatKind::frequency,
+        }
+    }
+}
+
+pub fn nanos_per_tick() -> u64 {
+    let ticks_per_second = sysconf::raw::sysconf(sysconf::raw::SysconfVariable::ScClkTck)
+        .expect("Failed to get Clock Ticks per Second") as u64;
+    SECOND / ticks_per_second
+}
+
+#[async_trait]
+impl Sampler for CpuSampler {
+    type Statistic = CpuStatKind;
+
+    fn new(common: Common) -> Result<Self, anyhow::Error> {
+        let statistics: HashSet<_> = common
+            .config()
+            .samplers()
+            .cpu()
+            .statistics()
+            .into_iter()
+            .map(CpuStatKind::from)
+            .collect();
+        let config = common.common_sampler_config(common.config().samplers().cpu());
+
+        #[allow(unused_mut)]
+        let mut sampler = Self {
+            common,
+            stats: CpuStats::with_config(&config),
+            cpus: HashSet::new(),
+            cstates: HashMap::new(),
+            cstate_files: HashMap::new(),
+            perf: None,
+            tick_duration: nanos_per_tick(),
+            proc_cpuinfo: None,
+            proc_stat: None,
+        };
+
+        if sampler.sampler_config().enabled() {
+            sampler.stats.register(&statistics);
+
+            // we initialize perf last so we can delay
+            #[cfg(feature = "bpf")]
+            if sampler.sampler_config().perf_events() {
+                // if let Err(e) = sampler
+            }
+        }
+
+        // delay by half the sample interval so that we land between perf
+        // counter updates
+        std::thread::sleep(std::time::Duration::from_micros(
+            (1000 * sampler.interval()) as u64 / 2,
+        ));
+
+        Ok(sampler)
+    }
+
+    fn spawn(common: Common) {
+        if common.config().samplers().cpu().enabled() {
+            if let Ok(mut cpu) = Self::new(common.clone()) {
+                common.runtime().spawn(async move {
+                    loop {
+                        let _ = cpu.sample().await;
+                    }
+                });
+            } else if !common.config.fault_tolerant() {
+                fatal!("failed to initialize cpu sampler");
+            } else {
+                error!("failed to initialize cpu sampler");
+            }
+        }
+    }
+
+    fn common(&self) -> &Common {
+        &self.common
+    }
+
+    fn common_mut(&mut self) -> &mut Common {
+        &mut self.common
+    }
+
+    fn sampler_config(&self) -> &dyn SamplerConfig<Statistic = Self::Statistic> {
+        self.common.config().samplers().cpu()
+    }
+
+    async fn sample(&mut self) -> Result<(), std::io::Error> {
+        if let Some(ref mut delay) = self.delay() {
+            delay.tick().await;
+        }
+
+        if !self.sampler_config().enabled() {
+            return Ok(());
+        }
+
+        debug!("sampling");
+
+        // we do perf sampling first, since it is time critical to keep it
+        // between underlying counter updates
+        #[cfg(feature = "bpf")]
+        {
+            let r = self.sample_bpf_perf_counters();
+            self.map_result(r)?;
+        }
+
+        let r = self.sample_cpuinfo().await;
+        self.map_result(r)?;
+
+        let r = self.sample_cpu_usage().await;
+        self.map_result(r)?;
+
+        let r = self.sample_cstates().await;
+        self.map_result(r)?;
+
+        Ok(())
+    }
+}
+
+impl CpuSampler {
+    #[cfg(feature = "bpf")]
+    fn initialize_bpf_perf(
+        &mut self,
+        statistics: &HashSet<CpuStatKind>,
+    ) -> Result<(), std::io::Error> {
+        use bcc::perf_event::{CacheId, CacheOp, CacheResult, HardwareEvent};
+
+        let cpus = crate::common::hardware_threads().unwrap();
+        let interval = self.interval() as u64;
+        let frequency = match interval {
+            0 => 1,
+            _ if interval > 1000 => 1,
+            _ => 1000 / interval,
+        };
+
+        let code = format!(
+            "{}\n{}",
+            format!("#define NUM_CPU {}", cpus),
+            include_str!("perf.c").to_string()
+        );
+
+        let mut bpf = match bcc::BPF::new(&code) {
+            Ok(bpf) => bpf,
+            Err(_) => {
+                if !self.common().config().general().fault_tolerant() {
+                    fatal!("failed to initialize perf bpf for cpu");
+                } else {
+                    error!("failed to initialize perf bpf for cpu");
+                }
+                return Ok(());
+            }
+        };
+
+        let events = [
+            (
+                "branch_instructions",
+                Event::Hardware(HardwareEvent::BranchInstructions),
+            ),
+            (
+                "branch_misses",
+                Event::Hardware(HardwareEvent::BranchMisses),
+            ),
+            (
+                "cache_references",
+                Event::Hardware(HardwareEvent::CacheReferences),
+            ),
+            ("cache_misses", Event::Hardware(HardwareEvent::CacheMisses)),
+            ("cycles", Event::Hardware(HardwareEvent::CpuCycles)),
+            (
+                "dtlb_load_miss",
+                Event::HardwareCache(CacheId::DTLB, CacheOp::Read, CacheResult::Miss),
+            ),
+            (
+                "dtlb_load_access",
+                Event::HardwareCache(CacheId::DTLB, CacheOp::Read, CacheResult::Access),
+            ),
+            (
+                "dtlb_store_miss",
+                Event::HardwareCache(CacheId::DTLB, CacheOp::Write, CacheResult::Miss),
+            ),
+            (
+                "dtlb_store_access",
+                Event::HardwareCache(CacheId::DTLB, CacheOp::Write, CacheResult::Access),
+            ),
+            ("instructions", Event::Hardware(HardwareEvent::Instructions)),
+        ];
+
+        for (table, event) in events {
+            if PerfEventArray::new()
+                .table(&format!("{}_array", table))
+                .event(event)
+                .attach(&mut bpf)
+                .is_err()
+            {
+                if !self.common().config().general().fault_tolerant() {
+                    fatal!("failed to initialize perf bpf for event: {:?}", event);
+                } else {
+                    error!("failed to initialize perf bpf for event: {:?}", event);
+                }
+            }
+        }
+
+        debug!("attaching software event to drive perf counter sampling");
+        if PerfEvent::new()
+            .handler("do_count")
+            .event(Event::Software(SoftwareEvent::CpuClock))
+            .sample_frequency(Some(frequency))
+            .attach(&mut bpf)
+            .is_err()
+        {
+            if !self.common().config().general().fault_tolerant() {
+                fatal!("failed to initialize perf bpf for cpu");
+            } else {
+                error!("failed to initialize perf bpf for cpu");
+            }
+        }
+        self.perf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));
+
+        Ok(())
+    }
+
+    async fn sample_cpu_usage(&mut self) -> Result<(), std::io::Error> {
+        if self.proc_stat.is_none() {
+            let file = File::open("/proc/stat").await?;
+            self.proc_stat = Some(file);
+        }
+
+        if let Some(file) = &mut self.proc_stat {
+            file.seek(SeekFrom::Start(0)).await?;
+            let time = Instant::now();
+
+            let mut reader = BufReader::new(file);
+            let mut buf = String::new();
+            while reader.read_line(&mut buf).await? > 0 {
+                Self::record_proc_stat(&self.stats, time, &buf);
+                buf.clear();
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn sample_cpuinfo(&mut self) -> Result<(), std::io::Error> {
+        if self.proc_cpuinfo.is_none() {
+            let file = File::open("/proc/cpuinfo").await?;
+            self.proc_cpuinfo = Some(file);
+        }
+
+        if let Some(file) = &mut self.proc_cpuinfo {
+            file.seek(SeekFrom::Start(0)).await?;
+            let mut reader = BufReader::new(file);
+            let mut buf = String::new();
+            let mut result = Vec::new();
+            while reader.read_line(&mut buf).await? > 0 {
+                if let Some(freq) = parse_frequency(&buf) {
+                    result.push(freq.ceil() as i64);
+                }
+                buf.clear();
+            }
+
+            let time = Instant::now();
+            info!("freq: {:?}", result);
+            for frequency in result {
+                self.stats.frequency.store(time, frequency);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "bpf")]
+    fn sample_bpf_perf_counters(&self) -> Result<(), std::io::Error> {
+        let bpf = match self.perf {
+            Some(ref bpf) => bpf,
+            None => return Ok(()),
+        };
+
+        let bpf = bpf.lock().unwrap();
+        let time = Instant::now();
+
+        let counters = [
+            ("branch_instructions", &self.stats.bpu_branches),
+            ("branch_misses", &self.stats.bpu_miss),
+            ("cache_misses", &self.stats.cache_miss),
+            ("cache_access", &self.stats.cache_access),
+            ("cycles", &self.stats.cycles),
+            ("dtlb_load_miss", &self.stats.dtlb_load_miss),
+            ("dtlb_load_access", &self.stats.dtlb_load_access),
+            ("dtlb_store_miss", &self.stats.dtlb_store_miss),
+            ("dtlb_store_access", &self.stats.dtlb_store_access),
+            ("instructions", &self.stats.instructions),
+            ("reference_cycles", &self.stats.reference_cycles),
+        ];
+
+        for (table, counter) in counters {
+            let table = match bpf.inner.table(table) {
+                Ok(table) => table,
+                Err(_) => continue,
+            };
+
+            let map = crate::common::bpf::perf_table_to_map(&table);
+            counter.store(time, map.iter().map(|(_, count)| count).sum());
+        }
+
+        Ok(())
+    }
+
+    async fn sample_cstates(&mut self) -> Result<(), std::io::Error> {
+        let mut result = HashMap::<CState, u64>::new();
+
+        // populate the cpu cache if empty
+        if self.cpus.is_empty() {
+            let cpu_regex = Regex::new(r"^cpu\d+$").unwrap();
+            let mut cpu_dir = tokio::fs::read_dir("/sys/devices/system/cpu").await?;
+            while let Some(cpu_entry) = cpu_dir.next_entry().await? {
+                if let Ok(cpu_name) = cpu_entry.file_name().into_string() {
+                    if cpu_regex.is_match(&cpu_name) {
+                        self.cpus.insert(cpu_name.to_string());
+                    }
+                }
+            }
+        }
+
+        // populate the cstate cache if empty
+        if self.cstates.is_empty() {
+            let state_regex = Regex::new(r"^state\d+$").unwrap();
+            for cpu in &self.cpus {
+                // iterate through all cpuidle states
+                let cpuidle_dir = format!("/sys/devices/system/cpu/{}/cpuidle", cpu);
+                let mut cpuidle_dir = tokio::fs::read_dir(cpuidle_dir).await?;
+                while let Some(cpuidle_entry) = cpuidle_dir.next_entry().await? {
+                    if let Ok(cpuidle_name) = cpuidle_entry.file_name().into_string() {
+                        if state_regex.is_match(&cpuidle_name) {
+                            // get the name of the state
+                            let name_file = format!(
+                                "/sys/devices/system/cpu/{}/cpuidle/{}/name",
+                                cpu, cpuidle_name
+                            );
+                            let mut name_file = File::open(name_file).await?;
+                            let mut name_content = Vec::new();
+                            name_file.read_to_end(&mut name_content).await?;
+                            if let Ok(name_string) = std::str::from_utf8(&name_content) {
+                                if let Some(Ok(state)) =
+                                    name_string.split_whitespace().next().map(|v| v.parse())
+                                {
+                                    self.cstates.insert(cpuidle_name, state);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for cpu in &self.cpus {
+            if !self.cstate_files.contains_key(cpu) {
+                self.cstate_files.insert(cpu.to_string(), HashMap::new());
+            }
+            if let Some(cpuidle_files) = self.cstate_files.get_mut(cpu) {
+                for (cpuidle_name, state) in &self.cstates {
+                    if !cpuidle_files.contains_key(cpuidle_name) {
+                        let time_file = format!(
+                            "/sys/devices/system/cpu/{}/cpuidle/{}/time",
+                            cpu, cpuidle_name
+                        );
+                        let file = File::open(time_file).await?;
+                        cpuidle_files.insert(cpuidle_name.to_string(), file);
+                    }
+
+                    let file = match cpuidle_files.get_mut(cpuidle_name) {
+                        Some(file) => file,
+                        None => continue,
+                    };
+
+                    file.seek(SeekFrom::Start(0)).await?;
+                    let mut reader = BufReader::new(file);
+
+                    let time = match reader.read_u64().await {
+                        Ok(time) => time,
+                        Err(_) => continue,
+                    };
+                    let state = match state.split('-').next() {
+                        Some(state) => state,
+                        None => continue,
+                    };
+                    let cstate = match CState::from_str(state) {
+                        Ok(cstate) => cstate,
+                        _ => continue
+                    };
+
+                    *result.entry(cstate).or_insert(0) += time * MICROSECOND;
+                }
+            }
+        }
+
+        let time = Instant::now();
+        let metrics = [
+            (CState::C0, &self.stats.cstate_c0_time),
+            (CState::C1, &self.stats.cstate_c1_time),
+            (CState::C1E, &self.stats.cstate_c1e_time),
+            (CState::C2, &self.stats.cstate_c2_time),
+            (CState::C3, &self.stats.cstate_c3_time),
+            (CState::C6, &self.stats.cstate_c6_time),
+            (CState::C7, &self.stats.cstate_c7_time),
+            (CState::C8, &self.stats.cstate_c8_time)
+        ];
+
+        for (cstate, metric) in metrics {
+            if let Some(&value) = result.get(&cstate) {
+                metric.store(time, value);
+            }
+        }
+
+        Ok(())
+    }
+
+    // Note: returns option to make the implementation easier
+    fn record_proc_stat(stats: &CpuStats, time: Instant, line: &str) -> Option<()> {
+        let mut iter = line.split_whitespace();
+
+        if iter.next()? != "cpu" {
+            return Some(());
+        }
+
+        let stats = [
+            &stats.usage_user,
+            &stats.usage_nice,
+            &stats.usage_system,
+            &stats.usage_idle,
+            &stats.usage_irq,
+            &stats.usage_softirq,
+            &stats.usage_steal,
+            &stats.usage_guest,
+            &stats.usage_guest_nice
+        ];
+
+        for (stat, value) in stats.into_iter().zip(iter) {
+            stat.store(time, value.parse().unwrap_or(0));
+        }
+
+        Some(())
+    }
+}
+
+fn parse_frequency(line: &str) -> Option<f64> {
+    let mut split = line.split_whitespace();
+    if split.next() == Some("cpu") && split.next() == Some("MHz") {
+        split.last().map(|v| v.parse().unwrap_or(0.0) * 1_000_000.0)
+    } else {
+        None
+    }
+}

--- a/src/samplers/cpu/stat.rs
+++ b/src/samplers/cpu/stat.rs
@@ -52,73 +52,74 @@ pub(super) struct CpuStats {
 impl CpuStats {
     pub fn new(common: &crate::samplers::Common, percentiles: &[f64]) -> Self {
         let span = Duration::from_secs(common.config().general().window() as _);
-        let heatmap = |name| HeatmapSummarizedCounter::new(name, span, percentiles);
+        let heatmap = || HeatmapSummarizedCounter::new(span, percentiles);
 
         Self {
-            usage_user: heatmap("cpu/usage/user"),
-            usage_nice: heatmap("cpu/usage/nice"),
-            usage_system: heatmap("cpu/usage/system"),
-            usage_idle: heatmap("cpu/usage/idle"),
-            usage_irq: heatmap("cpu/usage/irq"),
-            usage_softirq: heatmap("cpu/usage/softirq"),
-            usage_steal: heatmap("cpu/usage/steal"),
-            usage_guest: heatmap("cpu/usage/guest"),
-            usage_guest_nice: heatmap("cpu/usage/guestnice"),
-            cache_miss: heatmap("cpu/cache/miss"),
-            cache_access: heatmap("cpu/cache/access"),
-            bpu_branches: heatmap("cpu/bpu/branch"),
-            bpu_miss: heatmap("cpu/bpu/miss"),
-            cycles: heatmap("cpu/cycles"),
-            dtlb_load_miss: heatmap("cpu/dtlb/load/miss"),
-            dtlb_load_access: heatmap("cpu/dtlb/load/access"),
-            dtlb_store_access: heatmap("cpu/dtlb/store/access"),
-            dtlb_store_miss: heatmap("cpu/dtlb/store/miss"),
-            instructions: heatmap("cpu/instructions"),
-            reference_cycles: heatmap("cpu/reference_cycles"),
-            cstate_c0_time: heatmap("cpu/cstate/c0/time"),
-            cstate_c1_time: heatmap("cpu/cstate/c1/time"),
-            cstate_c1e_time: heatmap("cpu/cstate/c1e/time"),
-            cstate_c2_time: heatmap("cpu/cstate/c2/time"),
-            cstate_c3_time: heatmap("cpu/cstate/c3/time"),
-            cstate_c6_time: heatmap("cpu/cstate/c6/time"),
-            cstate_c7_time: heatmap("cpu/cstate/c7/time"),
-            cstate_c8_time: heatmap("cpu/cstate/c8/time"),
-            frequency: HeatmapSummarizedGauge::new("cpu/frequency", span, percentiles),
+            usage_user: heatmap(),
+            usage_nice: heatmap(),
+            usage_system: heatmap(),
+            usage_idle: heatmap(),
+            usage_irq: heatmap(),
+            usage_softirq: heatmap(),
+            usage_steal: heatmap(),
+            usage_guest: heatmap(),
+            usage_guest_nice: heatmap(),
+            cache_miss: heatmap(),
+            cache_access: heatmap(),
+            bpu_branches: heatmap(),
+            bpu_miss: heatmap(),
+            cycles: heatmap(),
+            dtlb_load_miss: heatmap(),
+            dtlb_load_access: heatmap(),
+            dtlb_store_access: heatmap(),
+            dtlb_store_miss: heatmap(),
+            instructions: heatmap(),
+            reference_cycles: heatmap(),
+            cstate_c0_time: heatmap(),
+            cstate_c1_time: heatmap(),
+            cstate_c1e_time: heatmap(),
+            cstate_c2_time: heatmap(),
+            cstate_c3_time: heatmap(),
+            cstate_c6_time: heatmap(),
+            cstate_c7_time: heatmap(),
+            cstate_c8_time: heatmap(),
+            frequency: HeatmapSummarizedGauge::new(span, percentiles),
         }
     }
 
-    pub fn disable_unwanted(&mut self, stats: &HashSet<CpuStatistic>) {
+    pub fn register(&mut self, stats: &HashSet<CpuStatistic>) {
         use self::CpuStatistic::*;
 
         if_block! {
-            if !stats.contains(&UsageUser) => self.usage_user.disable();
-            if !stats.contains(&UsageNice) => self.usage_nice.disable();
-            if !stats.contains(&UsageSystem) => self.usage_system.disable();
-            if !stats.contains(&UsageIdle) => self.usage_idle.disable();
-            if !stats.contains(&UsageIrq) => self.usage_irq.disable();
-            if !stats.contains(&UsageSoftirq) => self.usage_softirq.disable();
-            if !stats.contains(&UsageSteal) => self.usage_steal.disable();
-            if !stats.contains(&UsageGuest) => self.usage_guest.disable();
-            if !stats.contains(&UsageGuestNice) => self.usage_guest_nice.disable();
-            if !stats.contains(&CacheMiss) => self.cache_miss.disable();
-            if !stats.contains(&CacheAccess) => self.cache_access.disable();
-            if !stats.contains(&BpuBranches) => self.bpu_branches.disable();
-            if !stats.contains(&BpuMiss) => self.bpu_miss.disable();
-            if !stats.contains(&Cycles) => self.cycles.disable();
-            if !stats.contains(&DtlbLoadMiss) => self.dtlb_load_miss.disable();
-            if !stats.contains(&DtlbLoadAccess) => self.dtlb_load_access.disable();
-            if !stats.contains(&DtlbStoreAccess) => self.dtlb_store_access.disable();
-            if !stats.contains(&DtlbStoreMiss) => self.dtlb_store_miss.disable();
-            if !stats.contains(&Instructions) => self.instructions.disable();
-            if !stats.contains(&ReferenceCycles) => self.reference_cycles.disable();
-            if !stats.contains(&CstateC0Time) => self.cstate_c0_time.disable();
-            if !stats.contains(&CstateC1Time) => self.cstate_c1_time.disable();
-            if !stats.contains(&CstateC2Time) => self.cstate_c2_time.disable();
-            if !stats.contains(&CstateC3Time) => self.cstate_c3_time.disable();
-            if !stats.contains(&CstateC6Time) => self.cstate_c6_time.disable();
-            if !stats.contains(&CstateC7Time) => self.cstate_c7_time.disable();
-            if !stats.contains(&CstateC8Time) => self.cstate_c8_time.disable();
-            if !stats.contains(&Frequency) => self.frequency.disable();
+            if stats.contains(&UsageUser) => self.usage_user.register("cpu/usage/user");
+            if stats.contains(&UsageNice) => self.usage_nice.register("cpu/usage/nice");
+            if stats.contains(&UsageSystem) => self.usage_system.register("cpu/usage/system");
+            if stats.contains(&UsageIdle) => self.usage_idle.register("cpu/usage/idle");
+            if stats.contains(&UsageIrq) => self.usage_irq.register("cpu/usage/irq");
+            if stats.contains(&UsageSoftirq) => self.usage_softirq.register("cpu/usage/softirq");
+            if stats.contains(&UsageSteal) => self.usage_steal.register("cpu/usage/steal");
+            if stats.contains(&UsageGuest) => self.usage_guest.register("cpu/usage/guest");
+            if stats.contains(&UsageGuestNice) => self.usage_guest_nice.register("cpu/usage/guestnice");
+            if stats.contains(&CacheMiss) => self.cache_miss.register("cpu/cache/miss");
+            if stats.contains(&CacheAccess) => self.cache_access.register("cpu/cache/access");
+            if stats.contains(&BpuBranches) => self.bpu_branches.register("cpu/bpu/branch");
+            if stats.contains(&BpuMiss) => self.bpu_miss.register("cpu/bpu/miss");
+            if stats.contains(&Cycles) => self.cycles.register("cpu/cycles");
+            if stats.contains(&DtlbLoadMiss) => self.dtlb_load_miss.register("cpu/dtlb/load/miss");
+            if stats.contains(&DtlbLoadAccess) => self.dtlb_load_access.register("cpu/dtlb/load/access");
+            if stats.contains(&DtlbStoreAccess) => self.dtlb_store_access.register("cpu/dtlb/store/access");
+            if stats.contains(&DtlbStoreMiss) => self.dtlb_store_miss.register("cpu/dtlb/store/miss");
+            if stats.contains(&Instructions) => self.instructions.register("cpu/instructions");
+            if stats.contains(&ReferenceCycles) => self.reference_cycles.register("cpu/reference_cycles");
+            if stats.contains(&CstateC0Time) => self.cstate_c0_time.register("cpu/cstate/c0/time");
+            if stats.contains(&CstateC1Time) => self.cstate_c1_time.register("cpu/cstate/c1/time");
+            if stats.contains(&CstateC1ETime) => self.cstate_c1e_time.register("cpu/cstate/c1e/time");
+            if stats.contains(&CstateC2Time) => self.cstate_c2_time.register("cpu/cstate/c2/time");
+            if stats.contains(&CstateC3Time) => self.cstate_c3_time.register("cpu/cstate/c3/time");
+            if stats.contains(&CstateC6Time) => self.cstate_c6_time.register("cpu/cstate/c6/time");
+            if stats.contains(&CstateC7Time) => self.cstate_c7_time.register("cpu/cstate/c7/time");
+            if stats.contains(&CstateC8Time) => self.cstate_c8_time.register("cpu/cstate/c8/time");
+            if stats.contains(&Frequency) => self.frequency.register("cpu/frequency");
         }
     }
 }

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -207,24 +207,18 @@ impl Disk {
                 while reader.read_line(&mut line).await? > 0 {
                     let parts: Vec<&str> = line.split_whitespace().collect();
                     if re.is_match(parts.get(2).unwrap_or(&"unknown")) {
-                        for (id, part) in parts.iter().enumerate() {
-                            match id {
-                                3 => *operations_read.get_or_insert(0) += part.parse().unwrap_or(0),
-                                5 => *bandwidth_read.get_or_insert(0) += part.parse().unwrap_or(0),
-                                7 => {
-                                    *operations_write.get_or_insert(0) += part.parse().unwrap_or(0)
-                                }
-                                9 => *bandwidth_write.get_or_insert(0) += part.parse().unwrap_or(0),
-                                14 => {
-                                    *operations_discard.get_or_insert(0) +=
-                                        part.parse().unwrap_or(0)
-                                }
-                                16 => {
-                                    *bandwidth_discard.get_or_insert(0) += part.parse().unwrap_or(0)
-                                }
-                                _ => (),
-                            }
-                        }
+                        let mut iter = parts.iter();
+
+                        let _ = || -> Option<()> {
+                            *operations_read.get_or_insert(0) += iter.nth(3)?.parse().unwrap_or(0);
+                            *bandwidth_read.get_or_insert(0) += iter.nth(2)?.parse().unwrap_or(0);
+                            *operations_write.get_or_insert(0) += iter.nth(2)?.parse().unwrap_or(0);
+                            *bandwidth_write.get_or_insert(0) += iter.nth(2)?.parse().unwrap_or(0);
+                            *operations_discard.get_or_insert(0) += iter.nth(5)?.parse().unwrap_or(0);
+                            *bandwidth_discard.get_or_insert(0) += iter.nth(2)?.parse().unwrap_or(0);
+
+                            None
+                        }();
                     }
                     line.clear();
                 }

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -10,6 +10,50 @@ use serde_derive::{Deserialize, Serialize};
 use strum::ParseError;
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
+use crate::metrics::{StreamSummarizedCounter, SummarizedDistribution};
+use std::collections::HashSet;
+use std::time::Duration;
+
+stats_struct! {
+    pub struct DiskStats {
+        pub bandwidth_read: StreamSummarizedCounter = "disk/read/bytes",
+        pub bandwidth_write: StreamSummarizedCounter = "disk/write/bytes",
+        pub bandwidth_discard: StreamSummarizedCounter = "disk/discard/bytes",
+        pub operations_read: StreamSummarizedCounter = "disk/read/operations",
+        pub operations_write: StreamSummarizedCounter = "disk/write/operations",
+        pub operations_discard: StreamSummarizedCounter = "disk/discard/operations",
+        pub latency_read: SummarizedDistribution = "disk/read/latency",
+        pub latency_write: SummarizedDistribution = "disk/write/latency",
+        pub device_latency_read: SummarizedDistribution = "disk/read/device_latency",
+        pub device_latency_write: SummarizedDistribution = "disk/write/device_latency",
+        pub queue_latency_read: SummarizedDistribution = "disk/read/queue_latency",
+        pub queue_latency_write: SummarizedDistribution = "disk/write/queue_latency",
+        pub io_size_read: SummarizedDistribution = "disk/read/io_size",
+        pub io_size_write: SummarizedDistribution = "disk/write/io_size",
+    }
+}
+
+impl DiskStats {
+    pub fn new(capacity: usize, span: Duration, percentiles: &[f64]) -> Self {
+        Self {
+            bandwidth_read: StreamSummarizedCounter::new(capacity, percentiles),
+            bandwidth_write: StreamSummarizedCounter::new(capacity, percentiles),
+            bandwidth_discard: StreamSummarizedCounter::new(capacity, percentiles),
+            operations_read: StreamSummarizedCounter::new(capacity, percentiles),
+            operations_write: StreamSummarizedCounter::new(capacity, percentiles),
+            operations_discard: StreamSummarizedCounter::new(capacity, percentiles),
+            latency_read: SummarizedDistribution::new(span, percentiles),
+            latency_write: SummarizedDistribution::new(span, percentiles),
+            device_latency_read: SummarizedDistribution::new(span, percentiles),
+            device_latency_write: SummarizedDistribution::new(span, percentiles),
+            queue_latency_read: SummarizedDistribution::new(span, percentiles),
+            queue_latency_write: SummarizedDistribution::new(span, percentiles),
+            io_size_read: SummarizedDistribution::new(span, percentiles),
+            io_size_write: SummarizedDistribution::new(span, percentiles),
+        }
+    }
+}
+
 #[derive(
     Clone,
     Copy,


### PR DESCRIPTION
# Problem
We're trying to convert all the downstream consumers of `rustcommon-metrics` and `rustcommon-fastmetrics` to `rustcommon-metrics-v2`. This PR converts rezolus over to the new metrics framework.

# Solution
TODO

This is a draft to show work-in-progress as I go.

