### PR TITLE
Add jitter and connections accepted/initiated counters to TCP sampler

### DIFF
--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -11,16 +11,71 @@
 #include <bcc/proto.h>
 #include <linux/tcp.h>
 
-struct info_t {
-    u64 ts;
-    u32 pid;
-    char task[TASK_COMM_LEN];
-};
+// stores the stats of a connection.
+struct sock_stats_t {
+    char task[TASK_COMM_LEN];           // process name
+    u64 ts;                             // the starting timestamp of this connection
+    u64 pid;                            // TGID/PID
+} __attribute__((packed));              // minimize the memory needed.
 
-BPF_HASH(start, struct sock *, struct info_t);
+// Map pid to the function param to map kprobe to kretprobe
+BPF_HASH(param_map, u64, u64);
+// Map a tcp connection to its statistics
+BPF_HASH(sock_stats_map, struct sock *, struct sock_stats_t);
 
+// histograms
 BPF_HISTOGRAM(connlat, int, 461);
 BPF_HISTOGRAM(srtt, int, 461);
+BPF_HISTOGRAM(jitter, int, 461);
+
+// counters
+BPF_ARRAY(conn_accepted, u64, 1);
+BPF_ARRAY(conn_initiated, u64, 1);
+
+// store a pointer by the pid
+static void store_ptr(u64 pid, u64 ptr)
+{
+    param_map.update(&pid, &ptr);
+}
+
+// fetch the pointer by the pid and remove the pid from the map.
+static u64 fetch_ptr(u64 pid)
+{
+    u64 *ptr = param_map.lookup(&pid);
+    if (!ptr) {
+        return 0;
+    }
+    u64 val = *ptr;
+    param_map.delete(&pid);
+    return val;
+}
+
+// helper function to get srtt from tcp and copy to BPF space from kernel space.
+static u32 get_srtt_us(struct tcp_sock *ts) {
+    u32 srtt_us = 0;
+    bpf_probe_read_kernel(&srtt_us, sizeof(srtt_us), (void *)&ts->srtt_us);
+    // we do >> 3 because the value recorded in ts->srtt_us is actually 8 times
+    // the value of real srtt for easier calculation.
+    // see the thread in: https://lkml.org/lkml/1998/9/12/41
+    // and source code in: https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp_input.c#L797
+    return srtt_us >> 3;
+}
+
+// helper function to get median deviation of srtt from tcp and copy to BPF space from kernel space.
+static u32 get_jitter_us(struct tcp_sock *ts) {
+    u32 mdev_us = 0;
+    bpf_probe_read_kernel(&mdev_us, sizeof(mdev_us), (void *)&ts->mdev_us);
+    // we do >> 2 because the value recorded in ts->mdev_us is actually 4 times
+    // the value of real mdev_us for easier calculation.
+    // see source code in: https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp_input.c#L838
+    return mdev_us >> 2;
+}
+
+// helper function to add value aotmically.
+static void add_value(u64* val, u64 delta) {
+    if (val)
+        lock_xadd(val, delta);
+}
 
 // histogram indexing
 static unsigned int value_to_index2(unsigned int value) {
@@ -56,15 +111,127 @@ static unsigned int value_to_index2(unsigned int value) {
     return index;
 }
 
+// kprobe handler for tcp_v4_connect and tcp_v6_connect
 int trace_connect(struct pt_regs *ctx, struct sock *sk)
 {
-    u32 pid = bpf_get_current_pid_tgid();
-    struct info_t info = {.pid = pid};
-    info.ts = bpf_ktime_get_ns();
-    bpf_get_current_comm(&info.task, sizeof(info.task));
-    start.update(&sk, &info);
+    struct sock_stats_t stats = {.pid = bpf_get_current_pid_tgid()};
+    stats.ts = bpf_ktime_get_ns();
+    bpf_get_current_comm(&stats.task, sizeof(stats.task));
+    // store the sock's stats.
+    sock_stats_map.update(&sk, &stats);
+    // store the sock's pointer to the pid so it can be used in return handler later.
+    store_ptr(stats.pid, (u64)sk);
+
     return 0;
 };
+
+// kretprobe handler for tcp_v4_connect and tcp_v6_connect's return.
+int trace_connect_return(struct pt_regs *ctx)
+{
+    // get the sock from the param_map we saved in trace_connect
+    struct sock *sk = (struct sock *)fetch_ptr(bpf_get_current_pid_tgid());
+    if (!sk)
+        return 0;
+    int ret = PT_REGS_RC(ctx);
+    // Non-zero retcode means the connection failed right away.
+    if (ret != 0) {
+        // clean up.
+        struct sock_stats_t *stats = sock_stats_map.lookup(&sk);
+        if (!stats)
+            return 0;
+        sock_stats_map.delete(&sk);
+    }
+    return 0;
+}
+
+// kprobe handler for tcp_finish_connect
+int trace_finish_connect(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
+{
+    struct sock_stats_t *stats = sock_stats_map.lookup(&sk);
+    if (!stats) {
+        return 0;
+    }
+    // increment counter
+    int loc = 0;
+    add_value(conn_initiated.lookup(&loc), 1);
+
+    return 0;
+}
+
+// kprobe handler for tcp_set_state
+int trace_tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
+{
+    // We only handle closed connection, so early exist for non close ones.
+    if (state != TCP_CLOSE)
+        return 0;
+
+    // cleanup the connection since it's closed.
+    struct sock_stats_t *stats = sock_stats_map.lookup(&sk);
+    if (!stats) {
+        return 0;
+    }
+    sock_stats_map.delete(&sk);
+    return 0;
+}
+
+// kretprobe handler for inet_socket_accept's return.
+int trace_inet_socket_accept_return(struct pt_regs *ctx)
+{
+    // inet_socket_accept returns sock* directly, so we get from PT_REGS_RC.
+    struct sock *sk = (struct sock *)PT_REGS_RC(ctx);
+    if (!sk)
+        return 0;
+
+    // check this is TCP
+    u8 protocol = 0;
+    // unfortunately, we need to have different handling for pre-4.10 and 4.10+
+    // for pre-4.10, sk_wmem_queued is following sk_protocol field.
+    // for 4.10+, sk_gso_max_segs is following sk_protocol field.
+    // in order to be compatiable, we handle both cases.
+    // we calculate the offset between sk_lingertime_offset and gso_max_segs_offset
+    // and for 4.10+, the offset is 4, otherwise it's pre-4.10.
+    // see details in -> https://github.com/iovisor/bcc/blob/04893e3bb1c03a97f6ea3835986abe6608062f6a/tools/tcpaccept.py#L120
+    int gso_max_segs_offset = offsetof(struct sock, sk_gso_max_segs);
+    int sk_lingertime_offset = offsetof(struct sock, sk_lingertime);
+
+    // get the sk_protocol bitfield
+    if (sk_lingertime_offset - gso_max_segs_offset == 4)
+        // 4.10+ with little endian
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        // get the sk_protocol bitfield, see https://elixir.bootlin.com/linux/v5.4/source/include/net/sock.h#L455.
+        protocol = *(u8 *)((u64)&sk->sk_gso_max_segs - 3); 
+    else
+        // pre-4.10 with little endian
+        protocol = *(u8 *)((u64)&sk->sk_wmem_queued - 3);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        // 4.10+ with big endian
+        protocol = *(u8 *)((u64)&sk->sk_gso_max_segs - 1);
+    else
+        // pre-4.10 with big endian
+        protocol = *(u8 *)((u64)&sk->sk_wmem_queued - 1);
+#else
+#error "Fix your compiler's __BYTE_ORDER__?!"
+#endif
+
+    // if the sock is not TCP, igonre.
+    if (protocol != IPPROTO_TCP)
+        return 0;
+
+    // create the sock stats for the new accepted connection.
+    struct sock_stats_t stats = {.pid = bpf_get_current_pid_tgid()};
+    struct tcp_sock *ts = tcp_sk(sk);
+    // we approximate the starting time to be current time minus the srtt.
+    stats.ts = bpf_ktime_get_ns() - get_srtt_us(ts) * 1000;
+    bpf_get_current_comm(&stats.task, sizeof(stats.task));
+    // store the sock's stats.
+    sock_stats_map.update(&sk, &stats);
+
+    // increment counter;
+    int loc = 0;
+    add_value(conn_accepted.lookup(&loc), 1);
+
+    return 0;
+}
 
 // See tcp_v4_do_rcv() and tcp_v6_do_rcv(). So TCP_ESTBALISHED and TCP_LISTEN
 // are fast path and processed elsewhere, and leftovers are processed by
@@ -76,28 +243,30 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
     if (skp->__sk_common.skc_state != TCP_SYN_SENT)
         return 0;
     // check start and calculate delta
-    struct info_t *infop = start.lookup(&skp);
-    if (infop == 0) {
+    struct sock_stats_t *stats = sock_stats_map.lookup(&skp);
+    if (stats == 0) {
         return 0;   // missed entry or filtered
     }
-    u64 ts = infop->ts;
+    u64 ts = stats->ts;
     u64 now = bpf_ktime_get_ns();
     u64 delta_us = (now - ts) / 1000ul;
     u64 index = value_to_index2(delta_us);
     connlat.increment(index);
 
-    start.delete(&skp);
     return 0;
 }
 
+// this is actually the fast path, we need to watch out for the overhead added here.
 int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
+    struct sock_stats_t *stats = sock_stats_map.lookup(&sk);
+    if (!stats)
+        return 0; // missed entry or filtered
+
     struct tcp_sock *ts = tcp_sk(sk);
-    // we do >> 3 because the value recorded in ts->srtt_us is actually 8 times
-    // the value of real srtt for easier calculation.
-    // see the thread in: https://lkml.org/lkml/1998/9/12/41
-    // and source code in: https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp_input.c#L797
-    u64 index = value_to_index2(ts->srtt_us >> 3);
-    srtt.increment(index);
+    // update srtt and jitter.
+    srtt.increment(value_to_index2(get_srtt_us(ts)));
+    jitter.increment(value_to_index2(get_jitter_us(ts)));
+
     return 0;
 }

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -237,14 +237,19 @@ impl Tcp {
                 for statistic in self.statistics.iter().filter(|s| s.bpf_table().is_some()) {
                     // if statistic is Counter
                     match statistic.source() {
-                        Source::Counter =>
+                        Source::Counter => {
                             if let Ok(table) = &(*bpf).inner.table(statistic.bpf_table().unwrap()) {
-                                let count = crate::common::bpf::parse_u64(table.iter().next().unwrap().value);
+                                let count = crate::common::bpf::parse_u64(
+                                    table.iter().next().unwrap().value,
+                                );
                                 let _ = self.metrics().record_counter(statistic, time, count);
                             }
+                        }
                         // if it's distribution
-                        Source::Distribution =>
-                            if let Ok(mut table) = (*bpf).inner.table(statistic.bpf_table().unwrap()) {
+                        Source::Distribution => {
+                            if let Ok(mut table) =
+                                (*bpf).inner.table(statistic.bpf_table().unwrap())
+                            {
                                 for (&value, &count) in &map_from_table(&mut table) {
                                     if count > 0 {
                                         let _ = self.metrics().record_bucket(
@@ -257,7 +262,8 @@ impl Tcp {
                                     }
                                 }
                             }
-                        _ => () // we do not support other types
+                        }
+                        _ => (), // we do not support other types
                     }
                 }
             }

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -130,7 +130,7 @@ impl Statistic<AtomicU64, AtomicU32> for TcpStatistic {
     fn source(&self) -> Source {
         match self.bpf_table() {
             Some("connlat") | Some("srtt") | Some("jitter") => Source::Distribution,
-            _ => Source::Counter
+            _ => Source::Counter,
         }
     }
 }

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -73,6 +73,12 @@ pub enum TcpStatistic {
     AbortOnTimeout,
     #[strum(serialize = "tcp/srtt")]
     SmoothedRoundTripTime,
+    #[strum(serialize = "tcp/jitter")]
+    MedianDevOfSmoothedRoundTripTime,
+    #[strum(serialize = "tcp/connection/accepted")]
+    ConnectionAccepted,
+    #[strum(serialize = "tcp/connection/initiated")]
+    ConnectionInitiated,
 }
 
 impl TcpStatistic {
@@ -108,6 +114,9 @@ impl TcpStatistic {
         match self {
             Self::ConnectLatency => Some("connlat"),
             Self::SmoothedRoundTripTime => Some("srtt"),
+            Self::MedianDevOfSmoothedRoundTripTime => Some("jitter"),
+            Self::ConnectionAccepted => Some("conn_accepted"),
+            Self::ConnectionInitiated => Some("conn_initiated"),
             _ => None,
         }
     }
@@ -119,10 +128,9 @@ impl Statistic<AtomicU64, AtomicU32> for TcpStatistic {
     }
 
     fn source(&self) -> Source {
-        if self.bpf_table().is_some() {
-            Source::Distribution
-        } else {
-            Source::Counter
+        match self.bpf_table() {
+            Some("connlat") | Some("srtt") | Some("jitter") => Source::Distribution,
+            _ => Source::Counter
         }
     }
 }


### PR DESCRIPTION
Problem
Add jitter (median deviation of srtt) and two counters
- connection accepted
- connection initiated
to the TCP sampler via BPF.

Solution
Added the above mentioned metrics by introducing new kernel probes in BPF.

Result
Three new metrics introduced to the TCP sampler.
tcp/jitter - histogram
tcp/connection/accepted - counter
tcp/connection/initiated - counter

