### PR TITLE
Put the shared value_to_index2 in a common place

### DIFF
--- a/src/common/value_to_index2.c
+++ b/src/common/value_to_index2.c
@@ -1,0 +1,36 @@
+/* This file contains the value_to_index2 that are shared,
+ * it's tailored to be replaced into the main bpf.c for each sampler */
+
+// histogram indexing
+static unsigned int value_to_index2(unsigned int value) {
+    unsigned int index = 460;
+    if (value < 100) {
+        // 0-99 => [0..100)
+        // 0 => 0
+        // 99 => 99
+        index = value;
+    } else if (value < 1000) {
+        // 100-999 => [100..190)
+        // 100 => 100
+        // 999 => 189
+        index = 90 + value / 10;
+    } else if (value < 10000) {
+        // 1_000-9_999 => [190..280)
+        // 1000 => 190
+        // 9999 => 279
+        index = 180 + value / 100;
+    } else if (value < 100000) {
+        // 10_000-99_999 => [280..370)
+        // 10000 => 280
+        // 99999 => 369
+        index = 270 + value / 1000;
+    } else if (value < 1000000) {
+        // 100_000-999_999 => [370..460)
+        // 100000 => 370
+        // 999999 => 459
+        index = 360 + value / 10000;
+    } else {
+        index = 460;
+    }
+    return index;
+}

--- a/src/samplers/disk/bpf.c
+++ b/src/samplers/disk/bpf.c
@@ -23,39 +23,8 @@ BPF_HISTOGRAM(io_size_write, int, 461);
 BPF_HISTOGRAM(latency_write, int, 461);
 BPF_HISTOGRAM(device_latency_write, int, 461);
 BPF_HISTOGRAM(queue_latency_write, int, 461);
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+
+VALUE_TO_INDEX2_FUNC
 
 int trace_pid_start(struct pt_regs *ctx, struct request *req)
 {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -134,7 +134,10 @@ impl Disk {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -134,7 +134,8 @@ impl Disk {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
                 // load + attach kprobes!
                 bcc::Kprobe::new()
                     .handler("trace_pid_start")

--- a/src/samplers/ext4/bpf.c
+++ b/src/samplers/ext4/bpf.c
@@ -19,39 +19,7 @@ BPF_HISTOGRAM(write, int, 461);
 BPF_HISTOGRAM(open, int, 461);
 BPF_HISTOGRAM(fsync, int, 461);
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 int trace_entry(struct pt_regs *ctx)
 {

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -126,6 +126,7 @@ impl Ext4 {
                 let addr = "0x".to_string()
                     + &crate::common::bpf::symbol_lookup("ext4_file_operations").unwrap();
                 let code = code.replace("EXT4_FILE_OPERATIONS", &addr);
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -126,7 +126,10 @@ impl Ext4 {
                 let addr = "0x".to_string()
                     + &crate::common::bpf::symbol_lookup("ext4_file_operations").unwrap();
                 let code = code.replace("EXT4_FILE_OPERATIONS", &addr);
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!

--- a/src/samplers/interrupt/bpf.c
+++ b/src/samplers/interrupt/bpf.c
@@ -33,39 +33,7 @@ BPF_HISTOGRAM(unknown, int, 461);
 BPF_HASH(hard_start, u32, u64);
 BPF_HISTOGRAM(hardirq_total, int, 461);
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 // Software IRQ
 int softirq_entry(struct tracepoint__irq__softirq_entry *args)

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -130,7 +130,10 @@ impl Interrupt {
                 debug!("initializing bpf");
 
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 bcc::Kprobe::new()

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -130,7 +130,8 @@ impl Interrupt {
                 debug!("initializing bpf");
 
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 bcc::Kprobe::new()
                     .handler("hardirq_entry")

--- a/src/samplers/network/bpf.c
+++ b/src/samplers/network/bpf.c
@@ -7,39 +7,7 @@
 BPF_HISTOGRAM(rx_size, int, 461);
 BPF_HISTOGRAM(tx_size, int, 461);
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 int trace_transmit(struct tracepoint__net__net_dev_queue *args)
 {

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -132,7 +132,8 @@ impl Network {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 bcc::Tracepoint::new()
                     .handler("trace_transmit")

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -132,7 +132,10 @@ impl Network {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 bcc::Tracepoint::new()

--- a/src/samplers/scheduler/bpf.c
+++ b/src/samplers/scheduler/bpf.c
@@ -62,39 +62,7 @@ struct sched_switch_arg {
     int next_prio;
 };
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 int trace_run(struct pt_regs *ctx, struct task_struct *prev)
 {

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -321,7 +321,10 @@ impl Scheduler {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -321,7 +321,8 @@ impl Scheduler {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -78,39 +78,7 @@ static void add_value(u64* val, u64 delta) {
         lock_xadd(val, delta);
 }
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 // kprobe handler for tcp_v4_connect and tcp_v6_connect
 int trace_connect(struct pt_regs *ctx, struct sock *sk)

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -134,7 +134,8 @@ impl Tcp {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -134,7 +134,10 @@ impl Tcp {
                 debug!("initializing bpf");
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!

--- a/src/samplers/xfs/bpf.c
+++ b/src/samplers/xfs/bpf.c
@@ -23,39 +23,7 @@ BPF_HISTOGRAM(write, int, 461);
 BPF_HISTOGRAM(open, int, 461);
 BPF_HISTOGRAM(fsync, int, 461);
 
-// histogram indexing
-static unsigned int value_to_index2(unsigned int value) {
-    unsigned int index = 460;
-    if (value < 100) {
-        // 0-99 => [0..100)
-        // 0 => 0
-        // 99 => 99
-        index = value;
-    } else if (value < 1000) {
-        // 100-999 => [100..190)
-        // 100 => 100
-        // 999 => 189
-        index = 90 + value / 10;
-    } else if (value < 10000) {
-        // 1_000-9_999 => [190..280)
-        // 1000 => 190
-        // 9999 => 279
-        index = 180 + value / 100;
-    } else if (value < 100000) {
-        // 10_000-99_999 => [280..370)
-        // 10000 => 280
-        // 99999 => 369
-        index = 270 + value / 1000;
-    } else if (value < 1000000) {
-        // 100_000-999_999 => [370..460)
-        // 100000 => 370
-        // 999999 => 459
-        index = 360 + value / 10000;
-    } else {
-        index = 460;
-    }
-    return index;
-}
+VALUE_TO_INDEX2_FUNC
 
 int trace_entry(struct pt_regs *ctx)
 {

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -124,7 +124,8 @@ impl Xfs {
 
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let mut bpf = bcc::BPF::new(code)?;
+                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!
                 bcc::Kprobe::new()

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -124,7 +124,10 @@ impl Xfs {
 
                 // load the code and compile
                 let code = include_str!("bpf.c");
-                let code = code.replace("VALUE_TO_INDEX2_FUNC", include_str!("../../common/value_to_index2.c"));
+                let code = code.replace(
+                    "VALUE_TO_INDEX2_FUNC",
+                    include_str!("../../common/value_to_index2.c"),
+                );
                 let mut bpf = bcc::BPF::new(&code)?;
 
                 // load + attach kprobes!


### PR DESCRIPTION
Problem

Currently the value_to_index2 function is repeated in every bpf.c file in each sampler that needs it.
We should put it in a common place and refer to that when building the BPF code.

Solution
Created a value_to_index2.c file that holds the function, loads it when building the bpf program and replace a predefined symbol with it in each bpf.c files that needs this function.

Result
value_to_index2 function centralised, removed repeated code.