### PR TITLE
Add TLP and retransmit timeouts counters to TCP sampler

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -499,7 +499,7 @@ This sampler provides telemetry about TCP traffic and connections.
 * `tcp/connection/initiated` - number of connections initiated actively
 * `tcp/drop` - number of packets dropped in the kernel TCP stack
 * `tcp/tlp` - number of Tail Loss Recovery Probes sent
-* `tcp/retransmit_timeout` - number of retransmit timeouts
+* `tcp/transmit/retransmit_timeout` - number of retransmit timeouts
 
 ## UDP
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -498,6 +498,7 @@ This sampler provides telemetry about TCP traffic and connections.
 * `tcp/connection/accepted` - number of connections accepted passively
 * `tcp/connection/initiated` - number of connections initiated actively
 * `tcp/drop` - number of packets dropped in the kernel TCP stack
+* `tcp/tlp` - number of Tail Loss Recovery Probes sent
 
 ## UDP
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -499,6 +499,7 @@ This sampler provides telemetry about TCP traffic and connections.
 * `tcp/connection/initiated` - number of connections initiated actively
 * `tcp/drop` - number of packets dropped in the kernel TCP stack
 * `tcp/tlp` - number of Tail Loss Recovery Probes sent
+* `tcp/retransmit_timeout` - number of retransmit timeouts
 
 ## UDP
 

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -33,6 +33,7 @@ BPF_ARRAY(conn_accepted, u64, 1);
 BPF_ARRAY(conn_initiated, u64, 1);
 BPF_ARRAY(drop, u64, 1);
 BPF_ARRAY(tlp, u64, 1);
+BPF_ARRAY(rto, u64, 1);
 
 // store a pointer by the pid
 static void store_ptr(u64 pid, u64 ptr)
@@ -259,5 +260,15 @@ int trace_tlp(struct pt_regs *ctx, struct sock *sk)
         return 0;
     int loc = 0;
     add_value(tlp.lookup(&loc), 1);
+    return 0;
+}
+
+// Count the amount of Retransmission Timeouts (RTO)
+int trace_rto(struct pt_regs *ctx, struct sock *sk) 
+{
+    if (sk == NULL)
+        return 0;
+    int loc = 0;
+    add_value(rto.lookup(&loc), 1);
     return 0;
 }

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -32,6 +32,7 @@ BPF_HISTOGRAM(jitter, int, 461);
 BPF_ARRAY(conn_accepted, u64, 1);
 BPF_ARRAY(conn_initiated, u64, 1);
 BPF_ARRAY(drop, u64, 1);
+BPF_ARRAY(tlp, u64, 1);
 
 // store a pointer by the pid
 static void store_ptr(u64 pid, u64 ptr)
@@ -240,11 +241,23 @@ int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
     return 0;
 }
 
+
+
 int trace_tcp_drop(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
     if (sk == NULL)
         return 0;
     int loc = 0;
     add_value(drop.lookup(&loc), 1);
+    return 0;
+}
+
+// Count the amount of Tail Loss Recovery Probes (TLP)
+int trace_tlp(struct pt_regs *ctx, struct sock *sk) 
+{
+    if (sk == NULL)
+        return 0;
+    int loc = 0;
+    add_value(tlp.lookup(&loc), 1);
     return 0;
 }

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -242,8 +242,6 @@ int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
     return 0;
 }
 
-
-
 int trace_tcp_drop(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
     if (sk == NULL)

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -169,6 +169,10 @@ impl Tcp {
                     .handler("trace_tlp")
                     .function("tcp_send_loss_probe")
                     .attach(&mut bpf)?;
+                    bcc::Kprobe::new()
+                    .handler("trace_rto")
+                    .function("tcp_retransmit_skb")
+                    .attach(&mut bpf)?;
 
                 // probes at returns
                 bcc::Kretprobe::new()

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -165,6 +165,10 @@ impl Tcp {
                     .handler("trace_tcp_drop")
                     .function("tcp_drop")
                     .attach(&mut bpf)?;
+                bcc::Kprobe::new()
+                    .handler("trace_tlp")
+                    .function("tcp_send_loss_probe")
+                    .attach(&mut bpf)?;
 
                 // probes at returns
                 bcc::Kretprobe::new()

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -171,7 +171,7 @@ impl Tcp {
                     .attach(&mut bpf)?;
                 bcc::Kprobe::new()
                     .handler("trace_rto")
-                    .function("tcp_retransmit_skb")
+                    .function("tcp_retransmit_timer")
                     .attach(&mut bpf)?;
 
                 // probes at returns

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -169,7 +169,7 @@ impl Tcp {
                     .handler("trace_tlp")
                     .function("tcp_send_loss_probe")
                     .attach(&mut bpf)?;
-                    bcc::Kprobe::new()
+                bcc::Kprobe::new()
                     .handler("trace_rto")
                     .function("tcp_retransmit_skb")
                     .attach(&mut bpf)?;

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -83,7 +83,7 @@ pub enum TcpStatistic {
     Drop,
     #[strum(serialize = "tcp/tlp")]
     TailLossProbe,
-    #[strum(serialize = "tcp/retransmit_timeout")]
+    #[strum(serialize = "tcp/transmit/retransmit_timeout")]
     RetransmitTimeout,
 }
 

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -81,6 +81,8 @@ pub enum TcpStatistic {
     ConnectionInitiated,
     #[strum(serialize = "tcp/drop")]
     Drop,
+    #[strum(serialize = "tcp/tlp")]
+    TailLossProbe,
 }
 
 impl TcpStatistic {
@@ -120,6 +122,7 @@ impl TcpStatistic {
             Self::ConnectionAccepted => Some("conn_accepted"),
             Self::ConnectionInitiated => Some("conn_initiated"),
             Self::Drop => Some("drop"),
+            Self::TailLossProbe => Some("tlp"),
             _ => None,
         }
     }

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -83,6 +83,8 @@ pub enum TcpStatistic {
     Drop,
     #[strum(serialize = "tcp/tlp")]
     TailLossProbe,
+    #[strum(serialize = "tcp/retransmit_timeout")]
+    RetransmitTimeout,
 }
 
 impl TcpStatistic {
@@ -123,6 +125,7 @@ impl TcpStatistic {
             Self::ConnectionInitiated => Some("conn_initiated"),
             Self::Drop => Some("drop"),
             Self::TailLossProbe => Some("tlp"),
+            Self::RetransmitTimeout => Some("rto"),
             _ => None,
         }
     }


### PR DESCRIPTION
Problem

Add two new TCP probes:
* A probe to measure Tail Loss Probes (TLP) sent.
* A probe to measure TCP Retransmit timeouts (RTO), reflecting how congested the network is.

Solution

Added two BPF kernel probes to count TLP and RTO events.

Result

Two new metrics introduced to TCP sampler: 
* tcp/ tlp
* tcp/retransmit_timeout