### PR TITLE
bpf: improve handling of partial failures

### DIFF
--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -156,7 +156,11 @@ impl Disk {
                             // attach only if 'blk_start_request' can be found.
                             if let Ok(results) = bpf.get_kprobe_functions("blk_start_request") {
                                 if !results.is_empty() {
-                                    probe.try_attach_to_bpf(&mut bpf)?
+                                    if self.common.config.fault_tolerant {
+                                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                                    } else {
+                                        probe.try_attach_to_bpf(&mut bpf)?;
+                                    }
                                 }
                             }
                         }
@@ -167,7 +171,11 @@ impl Disk {
                                 bpf.get_kprobe_functions("blk_account_io_completion")
                             {
                                 if !results.is_empty() {
-                                    probe.try_attach_to_bpf(&mut bpf)?
+                                    if self.common.config.fault_tolerant {
+                                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                                    } else {
+                                        probe.try_attach_to_bpf(&mut bpf)?;
+                                    }
                                 }
                             }
                         }
@@ -178,11 +186,22 @@ impl Disk {
                                 bpf.get_kprobe_functions("blk_account_io_completion")
                             {
                                 if results.is_empty() {
-                                    probe.try_attach_to_bpf(&mut bpf)?
+                                    if self.common.config.fault_tolerant {
+                                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                                    } else {
+                                        probe.try_attach_to_bpf(&mut bpf)?;
+                                    }
                                 }
                             }
                         }
-                        _ => probe.try_attach_to_bpf(&mut bpf)?,
+                        _ => {
+                            // load + attach the kernel probes that are required to the bpf instance.
+                            if self.common.config.fault_tolerant {
+                                let _ = probe.try_attach_to_bpf(&mut bpf);
+                            } else {
+                                probe.try_attach_to_bpf(&mut bpf)?;
+                            }
+                        }
                     }
                 }
 

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -156,7 +156,7 @@ impl Disk {
                             // attach only if 'blk_start_request' can be found.
                             if let Ok(results) = bpf.get_kprobe_functions("blk_start_request") {
                                 if !results.is_empty() {
-                                    if self.common.config.fault_tolerant {
+                                    if self.common.config.fault_tolerant() {
                                         let _ = probe.try_attach_to_bpf(&mut bpf);
                                     } else {
                                         probe.try_attach_to_bpf(&mut bpf)?;
@@ -171,7 +171,7 @@ impl Disk {
                                 bpf.get_kprobe_functions("blk_account_io_completion")
                             {
                                 if !results.is_empty() {
-                                    if self.common.config.fault_tolerant {
+                                    if self.common.config.fault_tolerant() {
                                         let _ = probe.try_attach_to_bpf(&mut bpf);
                                     } else {
                                         probe.try_attach_to_bpf(&mut bpf)?;
@@ -186,7 +186,7 @@ impl Disk {
                                 bpf.get_kprobe_functions("blk_account_io_completion")
                             {
                                 if results.is_empty() {
-                                    if self.common.config.fault_tolerant {
+                                    if self.common.config.fault_tolerant() {
                                         let _ = probe.try_attach_to_bpf(&mut bpf);
                                     } else {
                                         probe.try_attach_to_bpf(&mut bpf)?;
@@ -196,7 +196,7 @@ impl Disk {
                         }
                         _ => {
                             // load + attach the kernel probes that are required to the bpf instance.
-                            if self.common.config.fault_tolerant {
+                            if self.common.config.fault_tolerant() {
                                 let _ = probe.try_attach_to_bpf(&mut bpf);
                             } else {
                                 probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -144,7 +144,7 @@ impl Ext4 {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -144,7 +144,11 @@ impl Ext4 {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -148,7 +148,7 @@ impl Interrupt {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -148,8 +148,13 @@ impl Interrupt {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
+
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))
             }
         }

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -150,7 +150,7 @@ impl Network {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -150,7 +150,11 @@ impl Network {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -139,7 +139,11 @@ impl PageCache {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -139,7 +139,7 @@ impl PageCache {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -344,7 +344,11 @@ impl Scheduler {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -344,7 +344,7 @@ impl Scheduler {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -154,7 +154,7 @@ impl Tcp {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -154,7 +154,11 @@ impl Tcp {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })))

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -142,7 +142,7 @@ impl Xfs {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    if self.common.config.fault_tolerant {
+                    if self.common.config.fault_tolerant() {
                         let _ = probe.try_attach_to_bpf(&mut bpf);
                     } else {
                         probe.try_attach_to_bpf(&mut bpf)?;

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -142,7 +142,11 @@ impl Xfs {
 
                 // load + attach the kernel probes that are required to the bpf instance.
                 for probe in probes {
-                    probe.try_attach_to_bpf(&mut bpf)?;
+                    if self.common.config.fault_tolerant {
+                        let _ = probe.try_attach_to_bpf(&mut bpf);
+                    } else {
+                        probe.try_attach_to_bpf(&mut bpf)?;
+                    }
                 }
 
                 self.bpf = Some(Arc::new(Mutex::new(BPF { inner: bpf })));


### PR DESCRIPTION
As our BPF sampling becomes more extensive, we can run into cases
where we have a partial failure initializing the BPF probes for
a given sampler. Currently, this will result in all BPF telemetry
being disabled within that sampler.

This change makes it so that the probe attach uses the fault
tolerance configuration to either swallow or raise the error.
