### PR TITLE
fix wrong config of example.toml

### DIFF
--- a/configs/example.toml
+++ b/configs/example.toml
@@ -62,11 +62,11 @@ perf_events = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -91,11 +91,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 # The ext4 sampler provides telemetry about ext4 filesystem operations.
@@ -120,11 +120,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 # This sampler reads from a JSON key-value http endpoint and can calculate
@@ -161,11 +161,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -188,11 +188,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -226,11 +226,11 @@ enabled = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -255,11 +255,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 # The NTP sampler provides basic telemetry for the running network time protocol
@@ -280,11 +280,11 @@ enabled = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 # The Nvidia sampler provides telemetry for Nvidia GPUs by using the NVML
@@ -308,11 +308,11 @@ enabled = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 # The page cache sampler provides telemetry about page cache hits and misses
@@ -335,11 +335,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -373,11 +373,11 @@ perf_events = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -398,11 +398,11 @@ enabled = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -426,11 +426,11 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -451,11 +451,11 @@ enabled = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]
 
 
@@ -481,9 +481,9 @@ bpf = true
 
 # The set of exported percentiles can be controlled by specifying them here
 # percentiles = [
-# 	"1.0",
-# 	"10.0",
-# 	"50.0",
-# 	"90.0",
-# 	"99.0",
+# 	1.0,
+# 	10.0,
+# 	50.0,
+# 	90.0,
+# 	99.0,
 # ]


### PR DESCRIPTION
Problem

  When i try to uncomment the **percentiles** config of example.toml, the process just exit with the prompt:

> invalid type: string "1.0", expected f64 for key `samplers.cpu.percentiles` at line 65 column 3
 
  After discarding the **double quotos** of the numbers, the program runs normaly.  It's just a minor problem, however it does mislead users who use it for the first time.  Maybe we should correct it.

Solution

  Correct the example.

Result


