### PR TITLE
metrics: move metrics library into this project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,7 +83,7 @@ checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -171,12 +162,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -190,7 +175,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -216,28 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
-dependencies = [
- "getrandom",
- "lazy_static",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,7 +221,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -268,11 +231,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -282,18 +245,18 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -302,29 +265,23 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "b979d76c9fcb84dffc80a73f7290da0f83e4c95773494674cb44b76d13a7a110"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctrlc"
@@ -373,22 +330,11 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "3.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
-dependencies = [
- "ahash",
- "cfg-if 0.1.10",
- "num_cpus",
-]
-
-[[package]]
-name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_cpus",
 ]
 
@@ -404,7 +350,7 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -559,7 +505,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -729,7 +675,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -826,7 +772,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi 0.3.9",
 ]
 
@@ -866,7 +812,16 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -946,7 +901,7 @@ checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -1102,7 +1057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1139,7 +1094,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -1200,12 +1155,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1337,8 +1286,9 @@ dependencies = [
  "async-trait",
  "bcc",
  "clap",
+ "crossbeam",
  "ctrlc",
- "dashmap 4.0.2",
+ "dashmap",
  "json",
  "kafka",
  "libc",
@@ -1349,13 +1299,16 @@ dependencies = [
  "regex",
  "reqwest",
  "rustcommon-atomics",
+ "rustcommon-heatmap",
  "rustcommon-logger",
- "rustcommon-metrics",
+ "rustcommon-streamstats",
+ "rustcommon-time",
  "serde",
  "serde_derive",
  "strum",
  "strum_macros",
  "sysconf",
+ "thiserror",
  "tiny_http",
  "tokio",
  "toml",
@@ -1382,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "serde",
 ]
@@ -1390,18 +1343,18 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
- "crossbeam",
  "rustcommon-atomics",
  "rustcommon-histogram",
+ "rustcommon-time",
  "thiserror",
 ]
 
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1410,32 +1363,31 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "log 0.4.14",
- "time",
-]
-
-[[package]]
-name = "rustcommon-metrics"
-version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
-dependencies = [
- "crossbeam",
- "dashmap 3.11.10",
- "rustcommon-atomics",
- "rustcommon-heatmap",
- "rustcommon-streamstats",
- "thiserror",
+ "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-streamstats"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?branch=master#88e07783af36f011b3847baf4f0bef0724c4eaad"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
+]
+
+[[package]]
+name = "rustcommon-time"
+version = "0.0.11"
+source = "git+https://github.com/twitter/rustcommon?branch=master#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "mach",
+ "time 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1618,7 +1570,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "core-foundation-sys",
  "doc-comment",
  "libc",
@@ -1668,12 +1620,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
+name = "time"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "crunchy",
+ "itoa",
+ "libc",
 ]
 
 [[package]]
@@ -1770,7 +1723,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1796,7 +1749,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rand",
  "static_assertions",
 ]
@@ -1871,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a21b1fc04977357c3a6187a56ebd91ab60b98328956c1dda501f4e04c7afcb"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "chrono",
  "enum-iterator",
  "getset",
@@ -1921,7 +1874,7 @@ version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1946,7 +1899,7 @@ version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.51"
 async-trait = "0.1.51"
 bcc = { version = "0.0.32", optional = true }
 clap = "2.34.0"
+crossbeam = "0.8.0"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 dashmap = "4.0.2"
 json = "0.12.4"
@@ -25,13 +26,16 @@ nvml-wrapper = "0.7.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.7", default-features = false, features = ["blocking"] }
 rustcommon-atomics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-heatmap = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon", branch = "master" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-streamstats = { git = "https://github.com/twitter/rustcommon", branch = "master" }
+rustcommon-time = { git = "https://github.com/twitter/rustcommon", branch = "master" }
 serde = "1.0.130"
 serde_derive = "1.0.130"
 strum = "0.23.0"
 strum_macros = "0.23.1"
 sysconf = "0.3.4"
+thiserror = "1.0.20"
 tiny_http = "0.8.2"
 tokio = { version = "1.14.0", features = ["full"] }
 toml = "0.5.8"

--- a/src/config/exposition/kafka.rs
+++ b/src/config/exposition/kafka.rs
@@ -7,6 +7,7 @@ use rustcommon_atomics::*;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(dead_code)]
 pub struct Kafka {
     #[serde(default = "default_enabled")]
     enabled: AtomicBool,

--- a/src/config/exposition/mod.rs
+++ b/src/config/exposition/mod.rs
@@ -12,6 +12,7 @@ use self::kafka::*;
 #[serde(deny_unknown_fields)]
 pub struct Exposition {
     #[serde(default)]
+    #[allow(dead_code)]
     kafka: Kafka,
 }
 

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -6,8 +6,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::*;
 use rustcommon_logger::*;
-use rustcommon_metrics::*;
 use tiny_http::{Method, Response, Server};
 
 use super::MetricsSnapshot;

--- a/src/exposition/kafka.rs
+++ b/src/exposition/kafka.rs
@@ -20,7 +20,7 @@ pub struct KafkaProducer {
 }
 
 impl KafkaProducer {
-    pub fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU32>>) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU64, AtomicU32>>) -> Self {
         Self {
             snapshot: MetricsSnapshot::new(metrics, config.general().reading_suffix()),
             producer: Producer::from_hosts(config.exposition().kafka().hosts())

--- a/src/exposition/kafka.rs
+++ b/src/exposition/kafka.rs
@@ -6,8 +6,8 @@ use std::convert::TryInto;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::*;
 use kafka::producer::{Producer, Record};
-use rustcommon_metrics_legacy::*;
 
 use crate::config::Config;
 use crate::exposition::MetricsSnapshot;

--- a/src/exposition/mod.rs
+++ b/src/exposition/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use rustcommon_metrics::*;
+use crate::*;
 
 mod http;
 #[cfg(feature = "push_kafka")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,17 +13,21 @@ use std::sync::Arc;
 
 use rustcommon_atomics::AtomicBool;
 use rustcommon_logger::Logger;
-use rustcommon_metrics::*;
 use tokio::runtime::Builder;
 
 mod common;
 mod config;
 mod exposition;
+mod metrics;
 mod samplers;
 
 use common::*;
 use config::Config;
+use metrics::*;
 use samplers::*;
+
+pub type Instant = rustcommon_time::Instant<Nanoseconds<u64>>;
+pub type Duration = rustcommon_time::Duration<Nanoseconds<u64>>;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // get config

--- a/src/metrics/channel/mod.rs
+++ b/src/metrics/channel/mod.rs
@@ -1,0 +1,185 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::metrics::entry::Entry;
+use crate::metrics::outputs::ApproxOutput;
+use crate::metrics::summary::SummaryStruct;
+use crate::metrics::traits::*;
+use crate::metrics::MetricsError;
+use crate::metrics::Output;
+use crate::metrics::Summary;
+use rustcommon_time::*;
+
+use crossbeam::atomic::AtomicCell;
+use dashmap::DashSet;
+use rustcommon_atomics::{Atomic, AtomicBool, Ordering};
+
+/// Internal type which stores fields necessary to track a corresponding
+/// statistic.
+pub struct Channel<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    refreshed: AtomicCell<Instant<Nanoseconds<u64>>>,
+    statistic: Entry<Value, Count>,
+    empty: AtomicBool,
+    reading: Value,
+    summary: Option<SummaryStruct<Value, Count>>,
+    outputs: DashSet<ApproxOutput>,
+}
+
+impl<Value, Count> Channel<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    /// Creates an empty channel for a statistic.
+    pub fn new(statistic: &dyn Statistic<Value, Count>) -> Self {
+        let summary = statistic.summary().map(|v| v.build());
+        Self {
+            empty: AtomicBool::new(true),
+            statistic: Entry::from(statistic),
+            reading: Default::default(),
+            refreshed: AtomicCell::new(Instant::<Nanoseconds<u64>>::now()),
+            summary,
+            outputs: Default::default(),
+        }
+    }
+
+    /// Records a bucket value + count pair into the summary.
+    pub fn record_bucket(
+        &self,
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) -> Result<(), MetricsError> {
+        if let Some(summary) = &self.summary {
+            summary.increment(time, value, count);
+            Ok(())
+        } else {
+            Err(MetricsError::NoSummary)
+        }
+    }
+
+    /// Updates a counter to a new value if the reading is newer than the stored
+    /// reading.
+    pub fn record_counter(
+        &self,
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+    ) {
+        let t0 = self.refreshed.load();
+        if time <= t0 {
+            return;
+        }
+        if !self.empty.load(Ordering::Relaxed) {
+            if let Some(summary) = &self.summary {
+                self.refreshed.store(time);
+                let v0 = self.reading.load(Ordering::Relaxed);
+                let dt = time - t0;
+                let dv = (value - v0).to_float();
+                let rate = (dv
+                    / (dt.as_secs() as f64 + dt.subsec_nanos() as f64 / 1_000_000_000.0))
+                    .ceil();
+                summary.increment(
+                    time,
+                    <Value as Atomic>::Primitive::from_float(rate),
+                    1_u8.into(),
+                );
+            }
+            self.reading.store(value, Ordering::Relaxed);
+        } else {
+            self.reading.store(value, Ordering::Relaxed);
+            self.empty.store(false, Ordering::Relaxed);
+            self.refreshed.store(time);
+        }
+    }
+
+    /// Increment a counter by an amount
+    pub fn increment_counter(&self, value: <Value as Atomic>::Primitive) {
+        self.empty.store(false, Ordering::Relaxed);
+        self.reading.fetch_add(value, Ordering::Relaxed);
+    }
+
+    /// Updates a gauge reading if the new value is newer than the stored value.
+    pub fn record_gauge(
+        &self,
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+    ) {
+        {
+            let t0 = self.refreshed.load();
+            if time <= t0 {
+                return;
+            }
+        }
+        if let Some(summary) = &self.summary {
+            summary.increment(time, value, 1_u8.into());
+        }
+        self.reading.store(value, Ordering::Relaxed);
+        self.empty.store(false, Ordering::Relaxed);
+        self.refreshed.store(time);
+    }
+
+    /// Returns a percentile across stored readings/rates/...
+    pub fn percentile(
+        &self,
+        percentile: f64,
+    ) -> Result<<Value as Atomic>::Primitive, MetricsError> {
+        if let Some(summary) = &self.summary {
+            summary.percentile(percentile).map_err(MetricsError::from)
+        } else {
+            Err(MetricsError::NoSummary)
+        }
+    }
+
+    /// Returns the main reading for the channel (eg: counter, gauge)
+    pub fn reading(&self) -> Result<<Value as Atomic>::Primitive, MetricsError> {
+        if !self.empty.load(Ordering::Relaxed) {
+            Ok(self.reading.load(Ordering::Relaxed))
+        } else {
+            Err(MetricsError::Empty)
+        }
+    }
+
+    /// Set a summary to be used for an existing channel
+    pub fn set_summary(&mut self, summary: Summary<Value, Count>) {
+        let summary = summary.build();
+        self.summary = Some(summary);
+    }
+
+    /// Set a summary to be used for an existing channel
+    pub fn add_summary(&mut self, summary: Summary<Value, Count>) {
+        if self.summary.is_none() {
+            self.set_summary(summary);
+        }
+    }
+
+    pub fn statistic(&self) -> &dyn Statistic<Value, Count> {
+        &self.statistic
+    }
+
+    pub fn outputs(&self) -> Vec<ApproxOutput> {
+        let mut ret = Vec::new();
+        for output in self.outputs.iter().map(|v| *v) {
+            ret.push(output);
+        }
+        ret
+    }
+
+    pub fn add_output(&self, output: Output) {
+        self.outputs.insert(ApproxOutput::from(output));
+    }
+
+    pub fn remove_output(&self, output: Output) {
+        self.outputs.remove(&ApproxOutput::from(output));
+    }
+}

--- a/src/metrics/entry/mod.rs
+++ b/src/metrics/entry/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use core::hash::Hash;
+use core::hash::Hasher;
+use core::marker::PhantomData;
+
+use crate::metrics::*;
+
+use rustcommon_atomics::Atomic;
+
+pub struct Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    name: String,
+    source: Source,
+    _value: PhantomData<Value>,
+    _count: PhantomData<Count>,
+}
+
+impl<Value, Count> Clone for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            source: self.source,
+            _value: self._value,
+            _count: self._count,
+        }
+    }
+}
+
+impl<Value, Count> Statistic<Value, Count> for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn source(&self) -> Source {
+        self.source
+    }
+}
+
+impl<Value, Count> Hash for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl<Value, Count> From<&dyn Statistic<Value, Count>> for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn from(statistic: &dyn Statistic<Value, Count>) -> Self {
+        Self {
+            name: statistic.name().to_string(),
+            source: statistic.source(),
+            _count: PhantomData,
+            _value: PhantomData,
+        }
+    }
+}
+impl<Value, Count> PartialEq for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl<Value, Count> Eq for Entry<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+}

--- a/src/metrics/error/mod.rs
+++ b/src/metrics/error/mod.rs
@@ -1,0 +1,76 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_heatmap::HeatmapError;
+use rustcommon_streamstats::StreamstatsError;
+use thiserror::Error;
+
+/// Possible errors returned by operations on a histogram.
+#[derive(Error, Debug, PartialEq)]
+pub enum MetricsError {
+    #[error("no samples for the statistic")]
+    /// The summary contains no samples.
+    Empty,
+    #[error("invalid percentile")]
+    /// The provided percentile is outside of the range 0.0 - 100.0 (inclusive)
+    InvalidPercentile,
+    #[error("statistic is not registered")]
+    /// The statistic has not been registered
+    NotRegistered,
+    #[error("no summary configured for the statistic")]
+    /// The statistic does not have a configured summary
+    NoSummary,
+    #[error("value out of range")]
+    /// The requested value is out of range.
+    OutOfRange,
+    #[error("method does not apply for this statistic")]
+    /// A method has been called which does not match the statistic source
+    SourceMismatch,
+}
+
+impl From<SummaryError> for MetricsError {
+    fn from(other: SummaryError) -> Self {
+        match other {
+            SummaryError::Empty => Self::Empty,
+            SummaryError::InvalidPercentile => Self::InvalidPercentile,
+            SummaryError::OutOfRange => Self::OutOfRange,
+            SummaryError::NoSummary => Self::NoSummary,
+        }
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum SummaryError {
+    #[error("summary contains no samples")]
+    /// The summary contains no samples.
+    Empty,
+    #[error("invalid percentile")]
+    /// The provided percentile is outside of the range 0.0 - 100.0 (inclusive)
+    InvalidPercentile,
+    #[error("no summary configured for the statistic")]
+    /// There is no summary for the statistic
+    NoSummary,
+    #[error("value out of range")]
+    /// The requested value is out of range.
+    OutOfRange,
+}
+
+impl From<HeatmapError> for SummaryError {
+    fn from(other: HeatmapError) -> Self {
+        match other {
+            HeatmapError::Empty => Self::Empty,
+            HeatmapError::InvalidPercentile => Self::InvalidPercentile,
+            HeatmapError::OutOfRange => Self::OutOfRange,
+        }
+    }
+}
+
+impl From<StreamstatsError> for SummaryError {
+    fn from(other: StreamstatsError) -> Self {
+        match other {
+            StreamstatsError::Empty => Self::Empty,
+            StreamstatsError::InvalidPercentile => Self::InvalidPercentile,
+        }
+    }
+}

--- a/src/metrics/metrics/mod.rs
+++ b/src/metrics/metrics/mod.rs
@@ -1,0 +1,345 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::metrics::channel::Channel;
+use crate::metrics::entry::Entry;
+use crate::metrics::outputs::ApproxOutput;
+use crate::metrics::*;
+
+use core::hash::{Hash, Hasher};
+
+use dashmap::DashMap;
+use rustcommon_atomics::*;
+use rustcommon_time::Instant;
+
+use std::collections::HashMap;
+
+/// `Metrics` serves as a registry of outputs which are included in snapshots.
+/// In addition, it serves as the core storage of measurements and summary
+/// producing aggregation structures. It is designed for concurrent access,
+/// making it useful for serving as a unified metrics library in multi-threaded
+/// applications.
+pub struct Metrics<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    channels: DashMap<String, Channel<Value, Count>>,
+}
+
+impl<'a, Value: 'a, Count: 'a> Default for Metrics<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn default() -> Self {
+        Self {
+            channels: DashMap::new(),
+        }
+    }
+}
+
+impl<'a, Value: 'a, Count: 'a> Metrics<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    /// Create a new empty metrics registry
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Begin tracking a new statistic without a corresponding output. Useful if
+    /// metrics will be retrieved and reported manually in a command-line tool.
+    pub fn register(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a)) {
+        if !self.channels.contains_key(statistic.name()) {
+            let channel = Channel::new(statistic);
+            self.channels.insert(statistic.name().to_string(), channel);
+        }
+    }
+
+    /// Stop tracking a statistics and any corresponding outputs.
+    pub fn deregister(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a)) {
+        self.channels.remove(statistic.name());
+    }
+
+    /// Adds a new output to the registry which will be included in future
+    /// snapshots. If the statistic is not already tracked, it will be
+    /// registered.
+    pub fn add_output(&self, statistic: &'a (dyn Statistic<Value, Count> + 'a), output: Output) {
+        self.register(statistic);
+        if let Some(channel) = self.channels.get_mut(statistic.name()) {
+            channel.add_output(output);
+        }
+    }
+
+    /// Remove an output from the registry so that it will not be included in
+    /// future snapshots. This will not remove the related datastructures for
+    /// the statistic even if no outputs remain. Use `deregister` method to stop
+    /// tracking a statistic entirely.
+    pub fn remove_output(&self, statistic: &dyn Statistic<Value, Count>, output: Output) {
+        if let Some(channel) = self.channels.get_mut(statistic.name()) {
+            channel.remove_output(output);
+        }
+    }
+
+    /// Set the `Summary` for an already registered `Statistic`. This can be
+    /// used when the parameters are not known at compile time. For example, if
+    /// a sampling rate is user configurable at runtime, the number of samples
+    /// may need to be higher for stream summaries.
+    pub fn set_summary(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        summary: Summary<Value, Count>,
+    ) {
+        if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
+            channel.set_summary(summary);
+        }
+    }
+
+    /// Conditionally add a `Summary` for a `Statistic` if one is not currently
+    /// set. This may be used for dynamically registered statistic types to
+    /// prevent clearing an existing summary.
+    pub fn add_summary(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        summary: Summary<Value, Count>,
+    ) {
+        if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
+            channel.add_summary(summary);
+        }
+    }
+
+    /// Remove all statistics and outputs.
+    pub fn clear(&self) {
+        self.channels.clear();
+    }
+
+    /// Record a bucket value + count pair for distribution based statistics.
+    /// Use this when the data points are taken from a histogram and the summary
+    /// for the statistic is a heatmap.
+    pub fn record_bucket(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) -> Result<(), MetricsError> {
+        if statistic.source() == Source::Distribution {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_bucket(time, value, count)
+            } else {
+                // statistic not registered
+                Err(MetricsError::NotRegistered)
+            }
+        } else {
+            // source mismatch
+            Err(MetricsError::SourceMismatch)
+        }
+    }
+
+    /// Record a counter observation for counter based statistics. May be used
+    /// with any summary type. Summaries will track secondly rates for counter
+    /// changes.
+    pub fn record_counter(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+    ) -> Result<(), MetricsError> {
+        if statistic.source() == Source::Counter {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_counter(time, value);
+                Ok(())
+            } else {
+                // statistic not registered
+                Err(MetricsError::NotRegistered)
+            }
+        } else {
+            // source mismatch
+            Err(MetricsError::SourceMismatch)
+        }
+    }
+
+    /// Increment a counter by some amount. Wraps around on overflow. Currently,
+    /// no summary statistics are calculated for increments to avoid complexity
+    /// with out-of-order increments.
+    pub fn increment_counter(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        value: <Value as Atomic>::Primitive,
+    ) -> Result<(), MetricsError> {
+        if statistic.source() == Source::Counter {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.increment_counter(value);
+                Ok(())
+            } else {
+                // statistic not registered
+                Err(MetricsError::NotRegistered)
+            }
+        } else {
+            // source mismatch
+            Err(MetricsError::SourceMismatch)
+        }
+    }
+
+    /// Record a gauge observation for gauge based statistics. May be used with
+    /// any summary type. Summary tracks instantaneous gauge readings.
+    pub fn record_gauge(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+    ) -> Result<(), MetricsError> {
+        if statistic.source() == Source::Gauge {
+            if let Some(channel) = self.channels.get(statistic.name()) {
+                channel.record_gauge(time, value);
+                Ok(())
+            } else {
+                // statistic not registered
+                Err(MetricsError::NotRegistered)
+            }
+        } else {
+            // source mismatch
+            Err(MetricsError::SourceMismatch)
+        }
+    }
+
+    /// Return a percentile for the given statistic. For counters, it is the
+    /// percentile of secondly rates across the summary. For gauges, it is the
+    /// percentile of gauge readings observed across the summary. For
+    /// distributions it is the percentile across the configured summary.
+    pub fn percentile(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+        percentile: f64,
+    ) -> Result<<Value as Atomic>::Primitive, MetricsError> {
+        if let Some(channel) = self.channels.get(statistic.name()) {
+            channel.percentile(percentile)
+        } else {
+            Err(MetricsError::NotRegistered)
+        }
+    }
+
+    /// Return the reading for the statistic. For counters and gauges, this is
+    /// the most recent measurement recorded.
+    // TODO: decide on how to handle distribution channels
+    pub fn reading(
+        &self,
+        statistic: &'a (dyn Statistic<Value, Count> + 'a),
+    ) -> Result<<Value as Atomic>::Primitive, MetricsError> {
+        if let Some(channel) = self.channels.get(statistic.name()) {
+            channel.reading()
+        } else {
+            Err(MetricsError::NotRegistered)
+        }
+    }
+
+    /// Generates a point-in-time snapshot of metric and value pairs.
+    pub fn snapshot(&self) -> HashMap<Metric<Value, Count>, <Value as Atomic>::Primitive> {
+        #[allow(unused_mut)]
+        let mut result = HashMap::new();
+        for entry in &self.channels {
+            let (_name, channel) = entry.pair();
+            for output in channel.outputs() {
+                if let Ok(value) = match Output::from(output) {
+                    Output::Reading => {
+                        self.reading(channel.statistic() as &dyn Statistic<Value, Count>)
+                    }
+                    Output::Percentile(percentile) => {
+                        self.percentile(channel.statistic(), percentile)
+                    }
+                } {
+                    result.insert(
+                        Metric {
+                            statistic: Entry::from(channel.statistic()),
+                            output,
+                        },
+                        value,
+                    );
+                }
+            }
+        }
+        result
+    }
+}
+
+/// A statistic and output pair which has a corresponding value
+// #[derive(PartialEq, Eq, Hash)]
+pub struct Metric<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    statistic: Entry<Value, Count>,
+    output: ApproxOutput,
+}
+
+impl<Value, Count> Hash for Metric<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.statistic.name().hash(state);
+        self.output.hash(state);
+    }
+}
+
+impl<Value, Count> PartialEq for Metric<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.statistic.name() == other.statistic.name() && self.output == other.output
+    }
+}
+
+impl<Value, Count> Eq for Metric<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+}
+
+impl<Value, Count> Metric<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    /// Get the statistic name for the metric
+    pub fn statistic(&self) -> &dyn Statistic<Value, Count> {
+        &self.statistic as &dyn Statistic<Value, Count>
+    }
+
+    /// Get the output
+    pub fn output(&self) -> Output {
+        Output::from(self.output)
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,132 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#![allow(dead_code)]
+
+mod channel;
+mod entry;
+mod error;
+#[allow(clippy::module_inception)]
+mod metrics;
+mod outputs;
+mod source;
+mod summary;
+mod traits;
+
+pub use error::MetricsError;
+pub use metrics::{Metric, Metrics};
+pub use outputs::Output;
+pub use source::Source;
+pub use summary::Summary;
+pub use traits::{Count, Primitive, Statistic, Value};
+
+// Re-export atomic trait and types for convenience
+pub use rustcommon_atomics::{Atomic, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
+// Re-export time types for convenience
+pub use rustcommon_time::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    enum TestStat {
+        Alpha,
+    }
+
+    impl Statistic<AtomicU64, AtomicU64> for TestStat {
+        fn name(&self) -> &str {
+            match self {
+                Self::Alpha => "alpha",
+            }
+        }
+
+        fn source(&self) -> Source {
+            match self {
+                Self::Alpha => Source::Counter,
+            }
+        }
+
+        fn summary(&self) -> Option<Summary<AtomicU64, AtomicU64>> {
+            match self {
+                Self::Alpha => Some(Summary::stream(1000)),
+            }
+        }
+    }
+
+    #[test]
+    fn basic() {
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        assert!(metrics.reading(&TestStat::Alpha).is_err());
+        metrics
+            .record_counter(&TestStat::Alpha, Instant::<Nanoseconds<u64>>::now(), 0)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+        let now = Instant::<Nanoseconds<u64>>::now();
+        metrics
+            .record_counter(&TestStat::Alpha, now + Duration::from_millis(500), 0)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 0.0), Ok(0));
+        metrics
+            .record_counter(&TestStat::Alpha, now + Duration::from_millis(1500), 1)
+            .expect("failed to record counter");
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 100.0), Ok(1));
+    }
+
+    #[test]
+    fn outputs() {
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        assert!(metrics.snapshot().is_empty());
+        metrics.add_output(&TestStat::Alpha, Output::Reading);
+        let _ = metrics.record_counter(&TestStat::Alpha, Instant::<Nanoseconds<u64>>::now(), 1);
+        assert_eq!(metrics.snapshot().len(), 1);
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+    }
+
+    #[test]
+    fn absolute_counter() {
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        let start = Instant::<Nanoseconds<u64>>::now();
+        assert!(metrics.reading(&TestStat::Alpha).is_err());
+        metrics.record_counter(&TestStat::Alpha, start, 0).unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(0));
+        metrics
+            .record_counter(
+                &TestStat::Alpha,
+                start + Duration::from_millis(1000),
+                1000000,
+            )
+            .unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1000000));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 99.9), Ok(1000000));
+        metrics
+            .record_counter(
+                &TestStat::Alpha,
+                start + Duration::from_millis(2000),
+                3000000,
+            )
+            .unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(3000000));
+        assert_eq!(metrics.percentile(&TestStat::Alpha, 99.9), Ok(2000000));
+        metrics.record_counter(&TestStat::Alpha, start, 42).unwrap();
+        assert_ne!(metrics.reading(&TestStat::Alpha), Ok(42));
+    }
+
+    #[test]
+    fn increment_counter() {
+        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        metrics.register(&TestStat::Alpha);
+        assert!(metrics.reading(&TestStat::Alpha).is_err());
+        metrics.increment_counter(&TestStat::Alpha, 1).unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+        metrics.increment_counter(&TestStat::Alpha, 0).unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(1));
+        metrics.increment_counter(&TestStat::Alpha, 10).unwrap();
+        assert_eq!(metrics.reading(&TestStat::Alpha), Ok(11));
+    }
+}

--- a/src/metrics/outputs/mod.rs
+++ b/src/metrics/outputs/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Internal representation which approximates the percentile
+#[derive(PartialEq, Eq, Hash, Copy, Clone)]
+pub enum ApproxOutput {
+    Reading,
+    Percentile(u64),
+}
+
+/// Defines an output that should be reported in a snapshot for a statistic
+#[derive(Copy, Clone)]
+pub enum Output {
+    /// A counter or gauge reading
+    Reading,
+    /// A percentile from a statistic summary
+    Percentile(f64),
+}
+
+impl From<Output> for ApproxOutput {
+    fn from(output: Output) -> Self {
+        match output {
+            Output::Reading => Self::Reading,
+            Output::Percentile(percentile) => {
+                Self::Percentile((percentile * 1000000.0).ceil() as u64)
+            }
+        }
+    }
+}
+
+impl From<ApproxOutput> for Output {
+    fn from(output: ApproxOutput) -> Self {
+        match output {
+            ApproxOutput::Reading => Self::Reading,
+            ApproxOutput::Percentile(percentile) => Self::Percentile(percentile as f64 / 1000000.0),
+        }
+    }
+}

--- a/src/metrics/source/mod.rs
+++ b/src/metrics/source/mod.rs
@@ -1,0 +1,14 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Defines the source for a given statistic
+#[derive(PartialEq, Eq, Debug, Hash, Copy, Clone)]
+pub enum Source {
+    /// Indicates that the source is a monotonically incrementing count.
+    Counter,
+    /// Indicates that the source is an instantaneous gauge reading.
+    Gauge,
+    /// Indicates that the source is an underlying distribution (histogram).
+    Distribution,
+}

--- a/src/metrics/summary/mod.rs
+++ b/src/metrics/summary/mod.rs
@@ -1,0 +1,131 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::metrics::error::SummaryError;
+use crate::metrics::*;
+use core::marker::PhantomData;
+
+use rustcommon_atomics::Atomic;
+use rustcommon_heatmap::{AtomicHeatmap, Duration, Instant};
+use rustcommon_streamstats::AtomicStreamstats;
+
+pub(crate) enum SummaryStruct<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    Heatmap(AtomicHeatmap<<Value as Atomic>::Primitive, Count>),
+    Stream(AtomicStreamstats<Value>),
+}
+
+impl<Value, Count> SummaryStruct<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    pub fn increment(
+        &self,
+        time: Instant<Nanoseconds<u64>>,
+        value: <Value as Atomic>::Primitive,
+        count: <Count as Atomic>::Primitive,
+    ) {
+        match self {
+            Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
+            Self::Stream(stream) => stream.insert(value),
+        }
+    }
+
+    pub fn percentile(
+        &self,
+        percentile: f64,
+    ) -> Result<<Value as Atomic>::Primitive, SummaryError> {
+        match self {
+            Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(SummaryError::from),
+            Self::Stream(stream) => stream.percentile(percentile).map_err(SummaryError::from),
+        }
+    }
+
+    pub fn heatmap(
+        max: <Value as Atomic>::Primitive,
+        precision: u8,
+        span: Duration<Nanoseconds<u64>>,
+        resolution: Duration<Nanoseconds<u64>>,
+    ) -> Self {
+        Self::Heatmap(AtomicHeatmap::new(max, precision, span, resolution))
+    }
+
+    pub fn stream(samples: usize) -> Self {
+        Self::Stream(AtomicStreamstats::new(samples))
+    }
+}
+
+enum SummaryType<Value>
+where
+    Value: crate::Value,
+    <Value as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive>,
+{
+    Heatmap(
+        <Value as Atomic>::Primitive,
+        u8,
+        Duration<Nanoseconds<u64>>,
+        Duration<Nanoseconds<u64>>,
+    ),
+    Stream(usize),
+}
+
+pub struct Summary<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    inner: SummaryType<Value>,
+    _count: PhantomData<Count>,
+}
+
+impl<Value, Count> Summary<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    pub fn heatmap(
+        max: <Value as Atomic>::Primitive,
+        precision: u8,
+        span: Duration<Nanoseconds<u64>>,
+        resolution: Duration<Nanoseconds<u64>>,
+    ) -> Summary<Value, Count> {
+        Self {
+            inner: SummaryType::Heatmap(max, precision, span, resolution),
+            _count: PhantomData,
+        }
+    }
+
+    pub fn stream(samples: usize) -> Summary<Value, Count> {
+        Self {
+            inner: SummaryType::Stream(samples),
+            _count: PhantomData,
+        }
+    }
+
+    pub(crate) fn build(&self) -> SummaryStruct<Value, Count> {
+        match self.inner {
+            SummaryType::Heatmap(max, precision, span, resolution) => {
+                SummaryStruct::heatmap(max, precision, span, resolution)
+            }
+            SummaryType::Stream(samples) => SummaryStruct::stream(samples),
+        }
+    }
+}

--- a/src/metrics/traits/count.rs
+++ b/src/metrics/traits/count.rs
@@ -1,0 +1,20 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_atomics::*;
+use rustcommon_heatmap::AtomicCounter;
+
+/// Count types are used internally for some types of summary datastructures,
+/// such as heatmaps. The selected atomic is used as the internal counter width.
+/// A well matched type would be large enough to hold maximum number of
+/// observations that would fall into the same bucket in a heatmap. Using types
+/// that are oversized will result in higher memory utilization for heatmap
+/// summaries, but has no effect on basic counter/gauge values or streaming
+/// summary sizes.
+pub trait Count: Atomic + Default + AtomicCounter {}
+
+impl Count for AtomicU8 {}
+impl Count for AtomicU16 {}
+impl Count for AtomicU32 {}
+impl Count for AtomicU64 {}

--- a/src/metrics/traits/float_convert.rs
+++ b/src/metrics/traits/float_convert.rs
@@ -1,0 +1,44 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub trait FloatConvert {
+    fn to_float(self) -> f64;
+    fn from_float(value: f64) -> Self;
+}
+
+impl FloatConvert for u64 {
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
+}
+
+impl FloatConvert for u32 {
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
+}
+
+impl FloatConvert for u16 {
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
+}
+
+impl FloatConvert for u8 {
+    fn to_float(self) -> f64 {
+        self as f64
+    }
+    fn from_float(value: f64) -> Self {
+        value as Self
+    }
+}

--- a/src/metrics/traits/mod.rs
+++ b/src/metrics/traits/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+mod count;
+mod float_convert;
+mod primitive;
+mod statistic;
+mod value;
+
+pub use count::Count;
+pub use float_convert::FloatConvert;
+pub use primitive::Primitive;
+pub use statistic::Statistic;
+pub use value::Value;

--- a/src/metrics/traits/primitive.rs
+++ b/src/metrics/traits/primitive.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::metrics::traits::*;
+
+use rustcommon_heatmap::Indexing;
+
+use core::ops::Sub;
+
+/// A trait that is used to track primitive types that correspond to supported
+/// atomic types.
+pub trait Primitive:
+    Ord + Indexing + Copy + From<u8> + Sub<Self, Output = Self> + FloatConvert
+{
+}
+
+impl Primitive for u8 {}
+impl Primitive for u16 {}
+impl Primitive for u32 {}
+impl Primitive for u64 {}

--- a/src/metrics/traits/statistic.rs
+++ b/src/metrics/traits/statistic.rs
@@ -1,0 +1,70 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use crate::metrics::{Primitive, Source, Summary};
+use rustcommon_atomics::Atomic;
+
+use core::hash::{Hash, Hasher};
+
+/// A statistic represents a named entity that has associated measurements which
+/// are recorded and metrics which are reported. This trait defines a set of
+/// methods which uniquely identify the statistic, help the metrics library
+/// track it appropriately, and allow including metadata in the exposition
+/// format.
+pub trait Statistic<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    /// The name is used to lookup the channel for the statistic and should be
+    /// unique for each statistic. This field is used to hash the statistic in
+    /// the core structure.
+    fn name(&self) -> &str;
+    /// Indicates which source type the statistic tracks.
+    fn source(&self) -> Source;
+    /// Optionally, specify a summary builder which configures a summary
+    /// aggregation for producing additional metrics such as percentiles.
+    fn summary(&self) -> Option<Summary<Value, Count>> {
+        None
+    }
+}
+
+impl<Value, Count> Hash for dyn Statistic<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().to_string().hash(state);
+    }
+}
+
+impl<Value, Count> PartialEq for dyn Statistic<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl<Value, Count> Eq for dyn Statistic<Value, Count>
+where
+    Value: crate::Value,
+    Count: crate::Count,
+    <Value as Atomic>::Primitive: Primitive,
+    <Count as Atomic>::Primitive: Primitive,
+    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+{
+}

--- a/src/metrics/traits/value.rs
+++ b/src/metrics/traits/value.rs
@@ -1,0 +1,17 @@
+// Copyright 2020 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use rustcommon_atomics::*;
+
+/// Value types may be used to store the primary value for a metric. For example
+/// counter readings, gauge readings, or buckets values from underlying
+/// distributions. Lower precision atomics help reduce in-memory representation
+/// for stored values and streaming summaries, but are unable to represent large
+/// counter and gauge values.
+pub trait Value: Atomic + Arithmetic + Default {}
+
+impl Value for AtomicU8 {}
+impl Value for AtomicU16 {}
+impl Value for AtomicU32 {}
+impl Value for AtomicU64 {}

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -6,7 +6,6 @@ use std::collections::{HashMap, HashSet};
 use std::io::SeekFrom;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 
 use async_trait::async_trait;
 #[cfg(feature = "bpf")]
@@ -21,7 +20,7 @@ use crate::common::bpf::BPF;
 use crate::common::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/cpu/stat.rs
+++ b/src/samplers/cpu/stat.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 #[cfg(feature = "bpf")]
 use bcc::perf_event::*;
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -272,9 +272,8 @@ impl Disk {
 
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
-        use std::convert::TryInto;
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window().try_into().unwrap(), 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             let time = Instant::now();
             if let Some(ref bpf) = self.bpf {

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::SeekFrom;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 
 use async_trait::async_trait;
 use regex::Regex;
@@ -17,7 +16,7 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -5,14 +5,13 @@
 #[cfg(feature = "bpf")]
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 
 use async_trait::async_trait;
 
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -162,7 +162,7 @@ impl Ext4 {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window() as u64, 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();

--- a/src/samplers/ext4/stat.rs
+++ b/src/samplers/ext4/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/http/mod.rs
+++ b/src/samplers/http/mod.rs
@@ -3,14 +3,13 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::io::{Error, ErrorKind};
-use std::time::*;
 
+use crate::metrics::{Output, Summary};
 use async_trait::async_trait;
-use rustcommon_metrics::*;
 
 use crate::config::*;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/http/stat.rs
+++ b/src/samplers/http/stat.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::metrics::*;
 use crate::Statistic;
-use rustcommon_metrics::*;
 
 // #[derive(Eq, PartialEq, Hash)]
 pub struct HttpStatistic {

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -310,7 +310,7 @@ impl Interrupt {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window() as u64, 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -6,17 +6,15 @@ use std::collections::HashMap;
 #[cfg(feature = "bpf")]
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::*;
-use tokio::io::SeekFrom;
 
 use async_trait::async_trait;
 use tokio::fs::File;
-use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, SeekFrom};
 
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/interrupt/stat.rs
+++ b/src/samplers/interrupt/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/krb5kdc/mod.rs
+++ b/src/samplers/krb5kdc/mod.rs
@@ -7,11 +7,11 @@ use async_trait::async_trait;
 #[cfg(feature = "bpf")]
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::{Common, Sampler};
+use crate::*;
 
 #[cfg(feature = "bpf")]
 use crate::common::bpf::bpf_hash_char_to_map;

--- a/src/samplers/krb5kdc/stat.rs
+++ b/src/samplers/krb5kdc/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -6,12 +6,10 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 
 use async_trait::async_trait;
-use rustcommon_metrics::*;
-use std::time::*;
 
 use crate::config::*;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/memcache/stat.rs
+++ b/src/samplers/memcache/stat.rs
@@ -4,7 +4,7 @@
 
 use crate::Statistic;
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct MemcacheStatistic {

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -3,18 +3,16 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::collections::HashMap;
-use std::time::*;
 use tokio::io::SeekFrom;
 
 use async_trait::async_trait;
 use regex::Regex;
-use rustcommon_metrics::*;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/memory/stat.rs
+++ b/src/samplers/memory/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -4,16 +4,14 @@
 
 use std::convert::TryInto;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
-use rustcommon_metrics::*;
 use tokio::runtime::Runtime;
 use tokio::time::{interval, Interval};
 
 use crate::config::General as GeneralConfig;
 use crate::config::{Config, SamplerConfig};
-use crate::HardwareInfo;
+use crate::*;
 
 pub mod cpu;
 pub mod disk;
@@ -83,7 +81,7 @@ pub trait Sampler: Sized + Send {
         if self.common_mut().interval().is_none() {
             let millis = self.interval() as u64;
             self.common_mut()
-                .set_interval(Some(interval(Duration::from_millis(millis))));
+                .set_interval(Some(interval(std::time::Duration::from_millis(millis))));
         }
         self.common_mut().interval()
     }
@@ -114,16 +112,15 @@ pub trait Sampler: Sized + Send {
                         Summary::heatmap(
                             1_000_000_000,
                             2,
-                            Duration::new(
+                            Duration::from_secs(
                                 self.common()
                                     .config()
                                     .general()
                                     .window()
                                     .try_into()
                                     .unwrap(),
-                                0,
                             ),
-                            Duration::new(1, 0),
+                            Duration::from_secs(1),
                         ),
                     );
                 } else {

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 #[cfg(feature = "bpf")]
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 use tokio::io::SeekFrom;
 
 use async_trait::async_trait;
@@ -16,7 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -211,7 +211,7 @@ impl Network {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window() as u64, 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             let time = Instant::now();
             if let Some(ref bpf) = self.bpf {

--- a/src/samplers/network/stat.rs
+++ b/src/samplers/network/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/ntp/mod.rs
+++ b/src/samplers/ntp/mod.rs
@@ -2,14 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::time::*;
-
 use async_trait::async_trait;
 
 use crate::common::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/ntp/stat.rs
+++ b/src/samplers/ntp/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/nvidia/mod.rs
+++ b/src/samplers/nvidia/mod.rs
@@ -3,7 +3,6 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use std::convert::TryInto;
-use std::time::*;
 
 use async_trait::async_trait;
 use nvml_wrapper::enum_wrappers::device::*;
@@ -11,7 +10,7 @@ use nvml_wrapper::NVML;
 
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/nvidia/stat.rs
+++ b/src/samplers/nvidia/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -159,7 +159,7 @@ impl PageCache {
     fn sample_bpf_counters(&mut self) -> Result<(), std::io::Error> {
         if let Some(ref bpf) = self.bpf {
             let bpf = bpf.lock().unwrap();
-            let time = std::time::Instant::now();
+            let time = Instant::now();
             let mut page_accessed = 0;
             let mut buffer_dirty = 0;
             let mut add_to_page_cache_lru = 0;

--- a/src/samplers/page_cache/stat.rs
+++ b/src/samplers/page_cache/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -12,8 +12,7 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 use crate::common::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
-use std::time::*;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/rezolus/stat.rs
+++ b/src/samplers/rezolus/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -7,21 +7,20 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::SeekFrom;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 
+use crate::metrics::{Source, Statistic};
 use async_trait::async_trait;
 #[cfg(feature = "bpf")]
 use bcc::perf_event::{Event, SoftwareEvent};
 #[cfg(feature = "bpf")]
 use bcc::{PerfEvent, PerfEventArray};
-use rustcommon_metrics::{Source, Statistic};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -253,12 +253,10 @@ impl Scheduler {
 
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
-        use crate::common::MICROSECOND;
-
         // sample bpf
         {
             if self.bpf_last.lock().unwrap().elapsed()
-                >= Duration::new(self.general_config().window() as u64, 0)
+                >= Duration::from_secs(self.general_config().window() as u64)
             {
                 if let Some(ref bpf) = self.bpf {
                     let bpf = bpf.lock().unwrap();

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -4,9 +4,9 @@
 
 use crate::common::SECOND;
 
+use crate::metrics::*;
 #[cfg(feature = "bpf")]
 use bcc::perf_event::*;
-use rustcommon_metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashMap;
 use std::io::SeekFrom;
-use std::time::*;
 
 use async_trait::async_trait;
 
@@ -13,7 +12,7 @@ use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
 
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/softnet/stat.rs
+++ b/src/samplers/softnet/stat.rs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::*;
+
 use num_derive::FromPrimitive;
-use rustcommon_metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -6,7 +6,6 @@
 use std::collections::HashSet;
 
 use std::sync::{Arc, Mutex};
-use std::time::*;
 use tokio::fs::File;
 
 use async_trait::async_trait;
@@ -14,8 +13,7 @@ use async_trait::async_trait;
 use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::{Common, Sampler};
-#[cfg(feature = "bpf")]
-use rustcommon_metrics::*;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -214,7 +214,7 @@ impl Tcp {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window() as u64, 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/udp/mod.rs
+++ b/src/samplers/udp/mod.rs
@@ -3,12 +3,11 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use async_trait::async_trait;
-use std::time::Instant;
 use tokio::fs::File;
 
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
-use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/udp/stat.rs
+++ b/src/samplers/udp/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 

--- a/src/samplers/usercall/mod.rs
+++ b/src/samplers/usercall/mod.rs
@@ -6,11 +6,11 @@ use async_trait::async_trait;
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 
 use crate::common::bpf::BPF;
 use crate::config::SamplerConfig;
 use crate::samplers::{Common, Sampler};
+use crate::*;
 
 #[cfg(feature = "bpf")]
 use crate::common::bpf::bpf_hash_char_to_map;

--- a/src/samplers/usercall/stat.rs
+++ b/src/samplers/usercall/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::{AtomicU32, AtomicU64, Source, Statistic};
+use crate::metrics::{AtomicU32, AtomicU64, Source, Statistic};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UsercallStatistic {

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -5,7 +5,6 @@
 #[cfg(feature = "bpf")]
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::*;
 
 use async_trait::async_trait;
 
@@ -13,6 +12,7 @@ use crate::common::bpf::*;
 use crate::config::SamplerConfig;
 use crate::samplers::Common;
 use crate::Sampler;
+use crate::*;
 
 mod config;
 mod stat;

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -161,7 +161,7 @@ impl Xfs {
     #[cfg(feature = "bpf")]
     fn sample_bpf(&self) -> Result<(), std::io::Error> {
         if self.bpf_last.lock().unwrap().elapsed()
-            >= Duration::new(self.general_config().window() as u64, 0)
+            >= Duration::from_secs(self.general_config().window() as u64)
         {
             if let Some(ref bpf) = self.bpf {
                 let bpf = bpf.lock().unwrap();

--- a/src/samplers/xfs/stat.rs
+++ b/src/samplers/xfs/stat.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_metrics::*;
+use crate::metrics::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 


### PR DESCRIPTION
rustcommon-metrics has a lot of functionality that is specific to
the type of derived metrics that we need for Rezolus. These metrics
are being dropped in the v2 metrics library and are not used by our
other projects.

By moving the library into Rezolus, we can focus on an
implementation that is most appropriate for this project without
the overhead of serving as a generic metrics framework.
