### PR TITLE
metrics: simplify

### DIFF
--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -19,11 +19,7 @@ pub struct Http {
 }
 
 impl Http {
-    pub fn new(
-        address: SocketAddr,
-        metrics: Arc<Metrics>,
-        count_label: Option<&str>,
-    ) -> Self {
+    pub fn new(address: SocketAddr, metrics: Arc<Metrics>, count_label: Option<&str>) -> Self {
         let server = tiny_http::Server::http(address);
         if server.is_err() {
             fatal!("Failed to open {} for HTTP Stats listener", address);

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -21,7 +21,7 @@ pub struct Http {
 impl Http {
     pub fn new(
         address: SocketAddr,
-        metrics: Arc<Metrics<AtomicU64, AtomicU32>>,
+        metrics: Arc<Metrics>,
         count_label: Option<&str>,
     ) -> Self {
         let server = tiny_http::Server::http(address);

--- a/src/exposition/kafka.rs
+++ b/src/exposition/kafka.rs
@@ -20,7 +20,7 @@ pub struct KafkaProducer {
 }
 
 impl KafkaProducer {
-    pub fn new(config: Arc<Config>, metrics: Arc<Metrics<AtomicU64, AtomicU32>>) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics>) -> Self {
         Self {
             snapshot: MetricsSnapshot::new(metrics, config.general().reading_suffix()),
             producer: Producer::from_hosts(config.exposition().kafka().hosts())

--- a/src/exposition/mod.rs
+++ b/src/exposition/mod.rs
@@ -17,14 +17,14 @@ pub use self::http::Http;
 pub use self::kafka::KafkaProducer;
 
 pub struct MetricsSnapshot {
-    metrics: Arc<Metrics<AtomicU64, AtomicU32>>,
-    snapshot: HashMap<Metric<AtomicU64, AtomicU32>, u64>,
+    metrics: Arc<Metrics>,
+    snapshot: HashMap<Metric, u64>,
     refreshed: Instant,
     count_label: Option<String>,
 }
 
-impl MetricsSnapshot {
-    pub fn new(metrics: Arc<Metrics<AtomicU64, AtomicU32>>, count_label: Option<&str>) -> Self {
+impl<'a> MetricsSnapshot {
+    pub fn new(metrics: Arc<Metrics>, count_label: Option<&str>) -> Self {
         Self {
             metrics,
             snapshot: HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // initialize metrics
     debug!("initializing metrics");
-    let metrics = Arc::new(Metrics::<AtomicU64, AtomicU32>::new());
+    let metrics = Arc::new(Metrics::new());
 
     // initialize async runtime
     debug!("initializing async runtime");

--- a/src/metrics/channel/mod.rs
+++ b/src/metrics/channel/mod.rs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_atomics::Arithmetic;
-use rustcommon_atomics::AtomicU64;
 use crate::metrics::entry::Entry;
 use crate::metrics::outputs::ApproxOutput;
 use crate::metrics::summary::SummaryStruct;
@@ -11,6 +9,8 @@ use crate::metrics::traits::*;
 use crate::metrics::MetricsError;
 use crate::metrics::Output;
 use crate::metrics::Summary;
+use rustcommon_atomics::Arithmetic;
+use rustcommon_atomics::AtomicU64;
 use rustcommon_time::*;
 
 use crossbeam::atomic::AtomicCell;
@@ -59,11 +59,7 @@ impl Channel {
 
     /// Updates a counter to a new value if the reading is newer than the stored
     /// reading.
-    pub fn record_counter(
-        &self,
-        time: Instant<Nanoseconds<u64>>,
-        value: u64,
-    ) {
+    pub fn record_counter(&self, time: Instant<Nanoseconds<u64>>, value: u64) {
         let t0 = self.refreshed.load();
         if time <= t0 {
             return;
@@ -77,11 +73,7 @@ impl Channel {
                 let rate = (dv
                     / (dt.as_secs() as f64 + dt.subsec_nanos() as f64 / 1_000_000_000.0))
                     .ceil();
-                summary.increment(
-                    time,
-                    u64::from_float(rate),
-                    1_u8.into(),
-                );
+                summary.increment(time, u64::from_float(rate), 1_u8.into());
             }
             self.reading.store(value, Ordering::Relaxed);
         } else {
@@ -98,11 +90,7 @@ impl Channel {
     }
 
     /// Updates a gauge reading if the new value is newer than the stored value.
-    pub fn record_gauge(
-        &self,
-        time: Instant<Nanoseconds<u64>>,
-        value: u64,
-    ) {
+    pub fn record_gauge(&self, time: Instant<Nanoseconds<u64>>, value: u64) {
         {
             let t0 = self.refreshed.load();
             if time <= t0 {
@@ -118,10 +106,7 @@ impl Channel {
     }
 
     /// Returns a percentile across stored readings/rates/...
-    pub fn percentile(
-        &self,
-        percentile: f64,
-    ) -> Result<u64, MetricsError> {
+    pub fn percentile(&self, percentile: f64) -> Result<u64, MetricsError> {
         if let Some(summary) = &self.summary {
             summary.percentile(percentile).map_err(MetricsError::from)
         } else {

--- a/src/metrics/entry/mod.rs
+++ b/src/metrics/entry/mod.rs
@@ -51,4 +51,4 @@ impl PartialEq for Entry {
     }
 }
 
-impl Eq for Entry { }
+impl Eq for Entry {}

--- a/src/metrics/entry/mod.rs
+++ b/src/metrics/entry/mod.rs
@@ -4,52 +4,24 @@
 
 use core::hash::Hash;
 use core::hash::Hasher;
-use core::marker::PhantomData;
 
 use crate::metrics::*;
 
-use rustcommon_atomics::Atomic;
-
-pub struct Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+pub struct Entry {
     name: String,
     source: Source,
-    _value: PhantomData<Value>,
-    _count: PhantomData<Count>,
 }
 
-impl<Value, Count> Clone for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl Clone for Entry {
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
             source: self.source,
-            _value: self._value,
-            _count: self._count,
         }
     }
 }
 
-impl<Value, Count> Statistic<Value, Count> for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl Statistic for Entry {
     fn name(&self) -> &str {
         &self.name
     }
@@ -59,55 +31,24 @@ where
     }
 }
 
-impl<Value, Count> Hash for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl Hash for Entry {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name.hash(state);
     }
 }
 
-impl<Value, Count> From<&dyn Statistic<Value, Count>> for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    fn from(statistic: &dyn Statistic<Value, Count>) -> Self {
+impl From<&dyn Statistic> for Entry {
+    fn from(statistic: &dyn Statistic) -> Self {
         Self {
             name: statistic.name().to_string(),
             source: statistic.source(),
-            _count: PhantomData,
-            _value: PhantomData,
         }
     }
 }
-impl<Value, Count> PartialEq for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl PartialEq for Entry {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
     }
 }
 
-impl<Value, Count> Eq for Entry<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-}
+impl Eq for Entry { }

--- a/src/metrics/metrics/mod.rs
+++ b/src/metrics/metrics/mod.rs
@@ -75,11 +75,7 @@ impl Metrics {
     /// used when the parameters are not known at compile time. For example, if
     /// a sampling rate is user configurable at runtime, the number of samples
     /// may need to be higher for stream summaries.
-    pub fn set_summary(
-        &self,
-        statistic: &dyn Statistic,
-        summary: Summary,
-    ) {
+    pub fn set_summary(&self, statistic: &dyn Statistic, summary: Summary) {
         if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
             channel.set_summary(summary);
         }
@@ -88,11 +84,7 @@ impl Metrics {
     /// Conditionally add a `Summary` for a `Statistic` if one is not currently
     /// set. This may be used for dynamically registered statistic types to
     /// prevent clearing an existing summary.
-    pub fn add_summary(
-        &self,
-        statistic: &dyn Statistic,
-        summary: Summary,
-    ) {
+    pub fn add_summary(&self, statistic: &dyn Statistic, summary: Summary) {
         if let Some(mut channel) = self.channels.get_mut(statistic.name()) {
             channel.add_summary(summary);
         }
@@ -212,10 +204,7 @@ impl Metrics {
     /// Return the reading for the statistic. For counters and gauges, this is
     /// the most recent measurement recorded.
     // TODO: decide on how to handle distribution channels
-    pub fn reading(
-        &self,
-        statistic: &dyn Statistic,
-    ) -> Result<u64, MetricsError> {
+    pub fn reading(&self, statistic: &dyn Statistic) -> Result<u64, MetricsError> {
         if let Some(channel) = self.channels.get(statistic.name()) {
             channel.reading()
         } else {
@@ -231,9 +220,7 @@ impl Metrics {
             let (_name, channel) = entry.pair();
             for output in channel.outputs() {
                 if let Ok(value) = match Output::from(output) {
-                    Output::Reading => {
-                        self.reading(channel.statistic() as &dyn Statistic)
-                    }
+                    Output::Reading => self.reading(channel.statistic() as &dyn Statistic),
                     Output::Percentile(percentile) => {
                         self.percentile(channel.statistic(), percentile)
                     }
@@ -272,7 +259,7 @@ impl PartialEq for Metric {
     }
 }
 
-impl Eq for Metric { }
+impl Eq for Metric {}
 
 impl Metric {
     /// Get the statistic name for the metric

--- a/src/metrics/metrics/mod.rs
+++ b/src/metrics/metrics/mod.rs
@@ -39,7 +39,7 @@ impl Metrics {
 
     /// Begin tracking a new statistic without a corresponding output. Useful if
     /// metrics will be retrieved and reported manually in a command-line tool.
-    pub fn register<'a>(&self, statistic: &dyn Statistic) {
+    pub fn register(&self, statistic: &dyn Statistic) {
         if !self.channels.contains_key(statistic.name()) {
             let channel = Channel::new(statistic);
             self.channels.insert(statistic.name().to_string(), channel);
@@ -47,7 +47,7 @@ impl Metrics {
     }
 
     /// Stop tracking a statistics and any corresponding outputs.
-    pub fn deregister<'a>(&self, statistic: &dyn Statistic) {
+    pub fn deregister(&self, statistic: &dyn Statistic) {
         self.channels.remove(statistic.name());
     }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -34,7 +34,7 @@ mod tests {
         Alpha,
     }
 
-    impl Statistic<AtomicU64, AtomicU64> for TestStat {
+    impl Statistic for TestStat {
         fn name(&self) -> &str {
             match self {
                 Self::Alpha => "alpha",
@@ -47,7 +47,7 @@ mod tests {
             }
         }
 
-        fn summary(&self) -> Option<Summary<AtomicU64, AtomicU64>> {
+        fn summary(&self) -> Option<Summary> {
             match self {
                 Self::Alpha => Some(Summary::stream(1000)),
             }
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn basic() {
-        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        let metrics = Metrics::new();
         metrics.register(&TestStat::Alpha);
         assert!(metrics.reading(&TestStat::Alpha).is_err());
         metrics
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn outputs() {
-        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        let metrics = Metrics::new();
         metrics.register(&TestStat::Alpha);
         assert!(metrics.snapshot().is_empty());
         metrics.add_output(&TestStat::Alpha, Output::Reading);
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn absolute_counter() {
-        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        let metrics = Metrics::new();
         metrics.register(&TestStat::Alpha);
         let start = Instant::<Nanoseconds<u64>>::now();
         assert!(metrics.reading(&TestStat::Alpha).is_err());
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn increment_counter() {
-        let metrics = Metrics::<AtomicU64, AtomicU64>::new();
+        let metrics = Metrics::new();
         metrics.register(&TestStat::Alpha);
         assert!(metrics.reading(&TestStat::Alpha).is_err());
         metrics.increment_counter(&TestStat::Alpha, 1).unwrap();

--- a/src/metrics/summary/mod.rs
+++ b/src/metrics/summary/mod.rs
@@ -8,30 +8,20 @@ use crate::metrics::*;
 use rustcommon_heatmap::{AtomicHeatmap, Duration, Instant};
 use rustcommon_streamstats::AtomicStreamstats;
 
-pub(crate) enum SummaryStruct
-{
+pub(crate) enum SummaryStruct {
     Heatmap(AtomicHeatmap<u64, AtomicU32>),
     Stream(AtomicStreamstats<AtomicU64>),
 }
 
-impl SummaryStruct
-{
-    pub fn increment(
-        &self,
-        time: Instant<Nanoseconds<u64>>,
-        value: u64,
-        count: u32,
-    ) {
+impl SummaryStruct {
+    pub fn increment(&self, time: Instant<Nanoseconds<u64>>, value: u64, count: u32) {
         match self {
             Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
             Self::Stream(stream) => stream.insert(value),
         }
     }
 
-    pub fn percentile(
-        &self,
-        percentile: f64,
-    ) -> Result<u64, SummaryError> {
+    pub fn percentile(&self, percentile: f64) -> Result<u64, SummaryError> {
         match self {
             Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(SummaryError::from),
             Self::Stream(stream) => stream.percentile(percentile).map_err(SummaryError::from),

--- a/src/metrics/summary/mod.rs
+++ b/src/metrics/summary/mod.rs
@@ -4,37 +4,23 @@
 
 use crate::metrics::error::SummaryError;
 use crate::metrics::*;
-use core::marker::PhantomData;
 
-use rustcommon_atomics::Atomic;
 use rustcommon_heatmap::{AtomicHeatmap, Duration, Instant};
 use rustcommon_streamstats::AtomicStreamstats;
 
-pub(crate) enum SummaryStruct<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+pub(crate) enum SummaryStruct
 {
-    Heatmap(AtomicHeatmap<<Value as Atomic>::Primitive, Count>),
-    Stream(AtomicStreamstats<Value>),
+    Heatmap(AtomicHeatmap<u64, AtomicU32>),
+    Stream(AtomicStreamstats<AtomicU64>),
 }
 
-impl<Value, Count> SummaryStruct<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
+impl SummaryStruct
 {
     pub fn increment(
         &self,
         time: Instant<Nanoseconds<u64>>,
-        value: <Value as Atomic>::Primitive,
-        count: <Count as Atomic>::Primitive,
+        value: u64,
+        count: u32,
     ) {
         match self {
             Self::Heatmap(heatmap) => heatmap.increment(time, value, count),
@@ -45,7 +31,7 @@ where
     pub fn percentile(
         &self,
         percentile: f64,
-    ) -> Result<<Value as Atomic>::Primitive, SummaryError> {
+    ) -> Result<u64, SummaryError> {
         match self {
             Self::Heatmap(heatmap) => heatmap.percentile(percentile).map_err(SummaryError::from),
             Self::Stream(stream) => stream.percentile(percentile).map_err(SummaryError::from),
@@ -53,7 +39,7 @@ where
     }
 
     pub fn heatmap(
-        max: <Value as Atomic>::Primitive,
+        max: u64,
         precision: u8,
         span: Duration<Nanoseconds<u64>>,
         resolution: Duration<Nanoseconds<u64>>,
@@ -66,14 +52,9 @@ where
     }
 }
 
-enum SummaryType<Value>
-where
-    Value: crate::Value,
-    <Value as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive>,
-{
+enum SummaryType {
     Heatmap(
-        <Value as Atomic>::Primitive,
+        u64,
         u8,
         Duration<Nanoseconds<u64>>,
         Duration<Nanoseconds<u64>>,
@@ -81,46 +62,29 @@ where
     Stream(usize),
 }
 
-pub struct Summary<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-    inner: SummaryType<Value>,
-    _count: PhantomData<Count>,
+pub struct Summary {
+    inner: SummaryType,
 }
 
-impl<Value, Count> Summary<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl Summary {
     pub fn heatmap(
-        max: <Value as Atomic>::Primitive,
+        max: u64,
         precision: u8,
         span: Duration<Nanoseconds<u64>>,
         resolution: Duration<Nanoseconds<u64>>,
-    ) -> Summary<Value, Count> {
+    ) -> Summary {
         Self {
             inner: SummaryType::Heatmap(max, precision, span, resolution),
-            _count: PhantomData,
         }
     }
 
-    pub fn stream(samples: usize) -> Summary<Value, Count> {
+    pub fn stream(samples: usize) -> Summary {
         Self {
             inner: SummaryType::Stream(samples),
-            _count: PhantomData,
         }
     }
 
-    pub(crate) fn build(&self) -> SummaryStruct<Value, Count> {
+    pub(crate) fn build(&self) -> SummaryStruct {
         match self.inner {
             SummaryType::Heatmap(max, precision, span, resolution) => {
                 SummaryStruct::heatmap(max, precision, span, resolution)

--- a/src/metrics/traits/statistic.rs
+++ b/src/metrics/traits/statistic.rs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::metrics::{Primitive, Source, Summary};
-use rustcommon_atomics::Atomic;
+use crate::metrics::{Source, Summary};
 
 use core::hash::{Hash, Hasher};
 
@@ -12,14 +11,7 @@ use core::hash::{Hash, Hasher};
 /// methods which uniquely identify the statistic, help the metrics library
 /// track it appropriately, and allow including metadata in the exposition
 /// format.
-pub trait Statistic<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+pub trait Statistic {
     /// The name is used to lookup the channel for the statistic and should be
     /// unique for each statistic. This field is used to hash the statistic in
     /// the core structure.
@@ -28,43 +20,21 @@ where
     fn source(&self) -> Source;
     /// Optionally, specify a summary builder which configures a summary
     /// aggregation for producing additional metrics such as percentiles.
-    fn summary(&self) -> Option<Summary<Value, Count>> {
+    fn summary(&self) -> Option<Summary> {
         None
     }
 }
 
-impl<Value, Count> Hash for dyn Statistic<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl Hash for dyn Statistic {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.name().to_string().hash(state);
     }
 }
 
-impl<Value, Count> PartialEq for dyn Statistic<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
+impl PartialEq for dyn Statistic {
     fn eq(&self, other: &Self) -> bool {
         self.name() == other.name()
     }
 }
 
-impl<Value, Count> Eq for dyn Statistic<Value, Count>
-where
-    Value: crate::Value,
-    Count: crate::Count,
-    <Value as Atomic>::Primitive: Primitive,
-    <Count as Atomic>::Primitive: Primitive,
-    u64: From<<Value as Atomic>::Primitive> + From<<Count as Atomic>::Primitive>,
-{
-}
+impl Eq for dyn Statistic { }

--- a/src/metrics/traits/statistic.rs
+++ b/src/metrics/traits/statistic.rs
@@ -37,4 +37,4 @@ impl PartialEq for dyn Statistic {
     }
 }
 
-impl Eq for dyn Statistic { }
+impl Eq for dyn Statistic {}

--- a/src/samplers/cpu/stat.rs
+++ b/src/samplers/cpu/stat.rs
@@ -86,7 +86,7 @@ pub enum CpuStatistic {
     Frequency,
 }
 
-impl Statistic<AtomicU64, AtomicU32> for CpuStatistic {
+impl Statistic for CpuStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -134,7 +134,7 @@ impl DiskStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for DiskStatistic {
+impl Statistic for DiskStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/ext4/stat.rs
+++ b/src/samplers/ext4/stat.rs
@@ -124,7 +124,7 @@ impl Ext4Statistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for Ext4Statistic {
+impl Statistic for Ext4Statistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/http/stat.rs
+++ b/src/samplers/http/stat.rs
@@ -17,7 +17,7 @@ impl HttpStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for HttpStatistic {
+impl Statistic for HttpStatistic {
     fn name(&self) -> &str {
         &self.name
     }

--- a/src/samplers/interrupt/stat.rs
+++ b/src/samplers/interrupt/stat.rs
@@ -164,7 +164,7 @@ impl InterruptStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for InterruptStatistic {
+impl Statistic for InterruptStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/krb5kdc/stat.rs
+++ b/src/samplers/krb5kdc/stat.rs
@@ -632,7 +632,7 @@ impl Krb5kdcStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for Krb5kdcStatistic {
+impl Statistic for Krb5kdcStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/memcache/stat.rs
+++ b/src/samplers/memcache/stat.rs
@@ -28,7 +28,7 @@ impl MemcacheStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for MemcacheStatistic {
+impl Statistic for MemcacheStatistic {
     fn name(&self) -> &str {
         &self.inner
     }

--- a/src/samplers/memory/stat.rs
+++ b/src/samplers/memory/stat.rs
@@ -203,7 +203,7 @@ impl MemoryStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for MemoryStatistic {
+impl Statistic for MemoryStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -184,11 +184,7 @@ impl Clone for Common {
 }
 
 impl Common {
-    pub fn new(
-        config: Arc<Config>,
-        metrics: Arc<Metrics>,
-        runtime: Arc<Runtime>,
-    ) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics>, runtime: Arc<Runtime>) -> Self {
         Self {
             config,
             hardware_info: Arc::new(HardwareInfo::new()),

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -55,7 +55,7 @@ pub use xfs::Xfs;
 
 #[async_trait]
 pub trait Sampler: Sized + Send {
-    type Statistic: Statistic<AtomicU64, AtomicU32>;
+    type Statistic: Statistic;
 
     /// Create a new instance of the sampler
     fn new(common: Common) -> Result<Self, anyhow::Error>;
@@ -141,7 +141,7 @@ pub trait Sampler: Sized + Send {
         ((1000.0 / self.interval() as f64) * self.general_config().window() as f64).ceil() as usize
     }
 
-    fn metrics(&self) -> &Metrics<AtomicU64, AtomicU32> {
+    fn metrics(&self) -> &Metrics {
         self.common().metrics()
     }
 
@@ -168,7 +168,7 @@ pub struct Common {
     runtime: Arc<Runtime>,
     hardware_info: Arc<HardwareInfo>,
     interval: Option<Interval>,
-    metrics: Arc<Metrics<AtomicU64, AtomicU32>>,
+    metrics: Arc<Metrics>,
 }
 
 impl Clone for Common {
@@ -186,7 +186,7 @@ impl Clone for Common {
 impl Common {
     pub fn new(
         config: Arc<Config>,
-        metrics: Arc<Metrics<AtomicU64, AtomicU32>>,
+        metrics: Arc<Metrics>,
         runtime: Arc<Runtime>,
     ) -> Self {
         Self {
@@ -218,7 +218,7 @@ impl Common {
         self.interval = interval
     }
 
-    pub fn metrics(&self) -> &Metrics<AtomicU64, AtomicU32> {
+    pub fn metrics(&self) -> &Metrics {
         &self.metrics
     }
 }

--- a/src/samplers/network/stat.rs
+++ b/src/samplers/network/stat.rs
@@ -121,7 +121,7 @@ impl NetworkStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for NetworkStatistic {
+impl Statistic for NetworkStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/ntp/stat.rs
+++ b/src/samplers/ntp/stat.rs
@@ -27,7 +27,7 @@ pub enum NtpStatistic {
     MaximumError,
 }
 
-impl Statistic<AtomicU64, AtomicU32> for NtpStatistic {
+impl Statistic for NtpStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/nvidia/stat.rs
+++ b/src/samplers/nvidia/stat.rs
@@ -96,7 +96,7 @@ pub enum NvidiaStatistic {
     ProcessesCompute(u32),
 }
 
-impl Statistic<AtomicU64, AtomicU32> for NvidiaStatistic {
+impl Statistic for NvidiaStatistic {
     // TODO(bmartin): this should be cleaned up once we have scoped metrics
     fn name(&self) -> &str {
         match self {

--- a/src/samplers/page_cache/stat.rs
+++ b/src/samplers/page_cache/stat.rs
@@ -82,7 +82,7 @@ impl PageCacheStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for PageCacheStatistic {
+impl Statistic for PageCacheStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/rezolus/stat.rs
+++ b/src/samplers/rezolus/stat.rs
@@ -31,7 +31,7 @@ pub enum RezolusStatistic {
     MemoryResident,
 }
 
-impl Statistic<AtomicU64, AtomicU32> for RezolusStatistic {
+impl Statistic for RezolusStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -109,7 +109,7 @@ impl SchedulerStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for SchedulerStatistic {
+impl Statistic for SchedulerStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/softnet/stat.rs
+++ b/src/samplers/softnet/stat.rs
@@ -38,7 +38,7 @@ pub enum SoftnetStatistic {
     FlowLimitCount = 5,
 }
 
-impl Statistic<AtomicU64, AtomicU32> for SoftnetStatistic {
+impl Statistic for SoftnetStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -270,7 +270,7 @@ impl TcpStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for TcpStatistic {
+impl Statistic for TcpStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/udp/stat.rs
+++ b/src/samplers/udp/stat.rs
@@ -39,7 +39,7 @@ impl UdpStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for UdpStatistic {
+impl Statistic for UdpStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }

--- a/src/samplers/usercall/mod.rs
+++ b/src/samplers/usercall/mod.rs
@@ -106,6 +106,7 @@ impl Usercall {
         // Add probes that are linked to specific files in the config
         for probe_config in self.libraries.iter().filter(|x| x.path.is_some()) {
             for func in probe_config.functions.iter() {
+                #[allow(clippy::format_in_format_args)]
                 bpf_probes.push_str(&format!(
                     probe_template!(),
                     found_probes.len(),
@@ -136,6 +137,7 @@ impl Usercall {
             for entry in &entries {
                 if path_match(&probe_config.name, entry.path()) {
                     for func in probe_config.functions.iter() {
+                        #[allow(clippy::format_in_format_args)]
                         bpf_probes.push_str(&format!(
                             probe_template!(),
                             found_probes.len(),

--- a/src/samplers/usercall/stat.rs
+++ b/src/samplers/usercall/stat.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::metrics::{AtomicU32, AtomicU64, Source, Statistic};
+use crate::metrics::{Source, Statistic};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UsercallStatistic {
     pub stat_path: String,
 }
 
-impl Statistic<AtomicU64, AtomicU32> for UsercallStatistic {
+impl Statistic for UsercallStatistic {
     fn name(&self) -> &str {
         &self.stat_path
     }

--- a/src/samplers/xfs/stat.rs
+++ b/src/samplers/xfs/stat.rs
@@ -124,7 +124,7 @@ impl XfsStatistic {
     }
 }
 
-impl Statistic<AtomicU64, AtomicU32> for XfsStatistic {
+impl Statistic for XfsStatistic {
     fn name(&self) -> &str {
         (*self).into()
     }


### PR DESCRIPTION
We can simplify the metrics by using concrete definitions and
removing the generics. This reduces the proliferation of type and
lifetime annotations.