### PR TITLE
make license headers consistent

### DIFF
--- a/src/common/bpf.rs
+++ b/src/common/bpf.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/config/exposition/kafka.rs
+++ b/src/config/exposition/kafka.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/config/exposition/mod.rs
+++ b/src/config/exposition/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/config/samplers.rs
+++ b/src/config/samplers.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/cpu/config.rs
+++ b/src/samplers/cpu/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/cpu/perf.c
+++ b/src/samplers/cpu/perf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/cpu/stat.rs
+++ b/src/samplers/cpu/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/disk/bpf.c
+++ b/src/samplers/disk/bpf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/disk/config.rs
+++ b/src/samplers/disk/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/disk/mod.rs
+++ b/src/samplers/disk/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/disk/stat.rs
+++ b/src/samplers/disk/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ext4/config.rs
+++ b/src/samplers/ext4/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ext4/mod.rs
+++ b/src/samplers/ext4/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ext4/stat.rs
+++ b/src/samplers/ext4/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/http/config.rs
+++ b/src/samplers/http/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/http/mod.rs
+++ b/src/samplers/http/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/http/stat.rs
+++ b/src/samplers/http/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/interrupt/config.rs
+++ b/src/samplers/interrupt/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/interrupt/mod.rs
+++ b/src/samplers/interrupt/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/interrupt/stat.rs
+++ b/src/samplers/interrupt/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memcache/config.rs
+++ b/src/samplers/memcache/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memcache/mod.rs
+++ b/src/samplers/memcache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memcache/stat.rs
+++ b/src/samplers/memcache/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memory/config.rs
+++ b/src/samplers/memory/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/memory/stat.rs
+++ b/src/samplers/memory/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/network/bpf.c
+++ b/src/samplers/network/bpf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/network/config.rs
+++ b/src/samplers/network/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/network/stat.rs
+++ b/src/samplers/network/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ntp/config.rs
+++ b/src/samplers/ntp/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ntp/mod.rs
+++ b/src/samplers/ntp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/ntp/stat.rs
+++ b/src/samplers/ntp/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/nvidia/config.rs
+++ b/src/samplers/nvidia/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/nvidia/mod.rs
+++ b/src/samplers/nvidia/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/nvidia/stat.rs
+++ b/src/samplers/nvidia/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/page_cache/config.rs
+++ b/src/samplers/page_cache/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/page_cache/mod.rs
+++ b/src/samplers/page_cache/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/page_cache/stat.rs
+++ b/src/samplers/page_cache/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/rezolus/config.rs
+++ b/src/samplers/rezolus/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/rezolus/mod.rs
+++ b/src/samplers/rezolus/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/rezolus/stat.rs
+++ b/src/samplers/rezolus/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/scheduler/config.rs
+++ b/src/samplers/scheduler/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/scheduler/perf.c
+++ b/src/samplers/scheduler/perf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/softnet/config.rs
+++ b/src/samplers/softnet/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/softnet/mod.rs
+++ b/src/samplers/softnet/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/softnet/stat.rs
+++ b/src/samplers/softnet/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/tcp/bpf.c
+++ b/src/samplers/tcp/bpf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/tcp/config.rs
+++ b/src/samplers/tcp/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/tcp/stat.rs
+++ b/src/samplers/tcp/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/udp/config.rs
+++ b/src/samplers/udp/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/udp/mod.rs
+++ b/src/samplers/udp/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/udp/stat.rs
+++ b/src/samplers/udp/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/xfs/bpf.c
+++ b/src/samplers/xfs/bpf.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/xfs/config.rs
+++ b/src/samplers/xfs/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/xfs/mod.rs
+++ b/src/samplers/xfs/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/samplers/xfs/stat.rs
+++ b/src/samplers/xfs/stat.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Twitter, Inc.
+// Copyright 2019 Twitter, Inc.
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
Some license headers had year ranges instead of just the file
creation year.

Changes all license headers to use just the file creation year.
