### PR TITLE
fix scheduler bpf for kernel >= 5.14

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -123,3 +123,43 @@ pub async fn nested_map_from_file(
 pub fn default_percentiles() -> Vec<f64> {
     vec![1.0, 10.0, 50.0, 90.0, 99.0]
 }
+
+#[allow(dead_code)]
+pub struct KernelInfo {
+    release: String,
+}
+
+#[allow(dead_code)]
+impl KernelInfo {
+    pub fn new() -> Result<Self, std::io::Error> {
+        let output = std::process::Command::new("uname").args(["-r"]).output()?;
+        let release = std::str::from_utf8(&output.stdout)
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+
+        Ok(Self {
+            release: release.to_string(),
+        })
+    }
+
+    pub fn release_major(&self) -> Result<u32, std::io::Error> {
+        let parts: Vec<&str> = self.release.split('.').collect();
+        if let Some(s) = parts.get(0) {
+            return s
+                .parse::<u32>()
+                .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput));
+        }
+        Err(std::io::Error::from(std::io::ErrorKind::InvalidInput))
+    }
+
+    pub fn release_minor(&self) -> Result<u32, std::io::Error> {
+        let parts: Vec<&str> = self.release.split('.').collect();
+        if let Some(s) = parts.get(1) {
+            return s
+                .parse::<u32>()
+                .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput));
+        }
+        Err(std::io::Error::from(std::io::ErrorKind::InvalidInput))
+    }
+}
+
+

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -161,5 +161,3 @@ impl KernelInfo {
         Err(std::io::Error::from(std::io::ErrorKind::InvalidInput))
     }
 }
-
-

--- a/src/samplers/scheduler/bpf.c
+++ b/src/samplers/scheduler/bpf.c
@@ -67,7 +67,7 @@ VALUE_TO_INDEX2_FUNC
 int trace_run(struct pt_regs *ctx, struct task_struct *prev)
 {
     // handle involuntary context switch
-    if (prev->state == TASK_RUNNING) {
+    if (prev->STATE_FIELD == TASK_RUNNING) {
         u32 tgid = prev->tgid;
         u32 pid = prev->pid;
         u64 ts = bpf_ktime_get_ns();


### PR DESCRIPTION
Fixes the scheduler sampler's bpf for kernel >= 5.14 for changes to
the task_struct state field.
