### PR TITLE
runqueue latency: fix for new kernels build with gcc >= 10

### DIFF
--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -4,7 +4,6 @@
 
 use crate::common::SECOND;
 use crate::metrics::*;
-use crate::*;
 #[cfg(feature = "bpf")]
 use bcc::perf_event::*;
 use serde_derive::{Deserialize, Serialize};
@@ -62,19 +61,9 @@ impl SchedulerStatistic {
     #[cfg(feature = "bpf")]
     pub fn bpf_probes_required(self) -> Vec<Probe> {
         // define the unique probes below.
-        // get info about the running kernel
-        let kernel_major = KernelInfo::new()
-            .map(|v| v.release_major().unwrap_or(5))
-            .unwrap_or(5);
-        let kernel_minor = KernelInfo::new()
-            .map(|v| v.release_minor().unwrap_or(0))
-            .unwrap_or(0);
 
-        let finish_task_switch = if kernel_major > 5 || (kernel_major == 5 && kernel_minor >= 14) {
-            "finish_task_switch.isra.0".to_string()
-        } else {
-            "finish_task_switch".to_string()
-        };
+        let finish_task_switch =
+            symbol_lookup("finish_task_switch.isra.0").unwrap_or("finish_task_switch".to_string());
 
         let finish_task_probe = Probe {
             name: finish_task_switch,

--- a/src/samplers/scheduler/stat.rs
+++ b/src/samplers/scheduler/stat.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::*;
 use crate::common::SECOND;
 use crate::metrics::*;
+use crate::*;
 #[cfg(feature = "bpf")]
 use bcc::perf_event::*;
 use serde_derive::{Deserialize, Serialize};
@@ -63,8 +63,12 @@ impl SchedulerStatistic {
     pub fn bpf_probes_required(self) -> Vec<Probe> {
         // define the unique probes below.
         // get info about the running kernel
-        let kernel_major = KernelInfo::new().map(|v| v.release_major().unwrap_or(5)).unwrap_or(5);
-        let kernel_minor = KernelInfo::new().map(|v| v.release_minor().unwrap_or(0)).unwrap_or(0);
+        let kernel_major = KernelInfo::new()
+            .map(|v| v.release_major().unwrap_or(5))
+            .unwrap_or(5);
+        let kernel_minor = KernelInfo::new()
+            .map(|v| v.release_minor().unwrap_or(0))
+            .unwrap_or(0);
 
         let finish_task_switch = if kernel_major > 5 || (kernel_major == 5 && kernel_minor >= 14) {
             "finish_task_switch.isra.0".to_string()


### PR DESCRIPTION
Simple fix to get runqueue latency to work for newer kernels which
are built with gcc >= 10
